### PR TITLE
Added missing link from the head manipulator group.

### DIFF
--- a/robots/herb.srdf.xacro
+++ b/robots/herb.srdf.xacro
@@ -129,6 +129,7 @@
 
     <xacro:macro name="pantilt" params="name">
         <group name="${name}">
+            <link name="/herb_base"/>
             <link name="/${name}/wam1"/>
             <link name="/${name}/wam2"/>
 


### PR DESCRIPTION
This fixes the missing `/head/wam1` joint on the OpenRAVE manipulator when loaded by or_urdf. See #5 for more information.
