### PR TITLE
Force the head joints to be revolute

### DIFF
--- a/config/herb_params.urdf.xacro
+++ b/config/herb_params.urdf.xacro
@@ -1,11 +1,11 @@
 <template xmlns:xacro="http://www.ros.org/wiki/xacro">
     <xacro:property name="pi" value="3.14159265359"/>
 
-    <joint name="head/wam1">
+    <joint name="head/wam1" type="revolute">
         <limit lower="${-160*(pi/180)}" upper="${160*(pi/180)}" effort="0.517" velocity="2.5"/>
     </joint>
 
-    <joint name="head/wam2">
+    <joint name="head/wam2" type="revolute">
         <limit lower="${-71.5*(pi/180)}" upper="${71.5*(pi/180)}" effort="0.110" velocity="2.5"/>
     </joint>
 </template>


### PR DESCRIPTION
These were exported from SolidWorks as CONTINUOUS. This causes issues with the bugfix in https://github.com/personalrobotics/or_urdf/pull/11.
