### PR TITLE
new rotation for kinect2_link

### DIFF
--- a/robots/fixed_transforms.urdf.xacro
+++ b/robots/fixed_transforms.urdf.xacro
@@ -59,7 +59,7 @@
             type="fixed">
             <origin
                 xyz="0.15837 0.03257 0.09936"
-                rpy="-1.570796 0 0" />
+                rpy="1.57079 -1.57019 1.57079" />
             <parent link="/head/wam2" />
             <child link="/head/kinect2_link"  />
         </joint>


### PR DESCRIPTION
Change rotation for "base" optical link to match what code-iai/iai_kinect2@42787f9bdd7ac04668f8ff85f3209059fca085d2 now depends on
