### PR TITLE
Adding ability to generate bh280 srdf.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,6 +167,15 @@ add_custom_target(herb_srdf ALL
     VERBATIM
 )
 
+xacro_expand("${PROJECT_SOURCE_DIR}/robots/bh280_standalone.srdf.xacro"
+             "${BASE_OUTPUT_DIR}/robots/bh280.srdf")
+add_custom_target(bh280_srdf ALL
+    DEPENDS "${URDF_OUTPUT_DIR}/bh280.srdf"
+    COMMENT "Generating BH280 SRDF"
+    VERBATIM
+)
+
+
 install(DIRECTORY "meshes"
                   "${URDF_OUTPUT_DIR}"
                   "${OPENRAVE_OUTPUT_DIR}"

--- a/robots/bh280_standalone.srdf.xacro
+++ b/robots/bh280_standalone.srdf.xacro
@@ -1,84 +1,83 @@
-<robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="bh280">
-    <xacro:macro name="bh280_hand">
-        <group name="hand">
-            <link name="/hand_base"/>
-            <link name="/finger0_0"/>
-            <link name="/finger0_1"/>
-            <link name="/finger0_2"/>
-            <link name="/finger1_0"/>
-            <link name="/finger1_1"/>
-            <link name="/finger1_2"/>
-            <link name="/finger2_1"/>
-            <link name="/finger2_2"/>
-        </group>
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="bh280"> 
+   <group name="hand">
+        <link name="/hand_base"/>
+        <link name="/finger0_0"/>
+        <link name="/finger0_1"/>
+        <link name="/finger0_2"/>
+        <link name="/finger1_0"/>
+        <link name="/finger1_1"/>
+        <link name="/finger1_2"/>
+        <link name="/finger2_1"/>
+        <link name="/finger2_2"/>
+    </group>
 
-        <!-- Disable collisions between the fingers. -->
-        <disable_collisions link1="/finger0_0" link2="/finger1_0"/>
-        <disable_collisions link1="/finger0_0" link2="/finger0_1"/>
-        <disable_collisions link1="/finger0_0" link2="/finger0_2"/>
-        <disable_collisions link1="/finger0_0" link2="/finger1_1"/>
-        <disable_collisions link1="/finger0_0" link2="/finger1_2"/>
-        <disable_collisions link1="/finger0_0" link2="/finger2_1"/>
-        <disable_collisions link1="/finger0_0" link2="/finger2_2"/>
+    <!-- Disable collisions between the fingers. -->
+    <disable_collisions link1="/finger0_0" link2="/finger1_0"/>
+    <disable_collisions link1="/finger0_0" link2="/finger0_1"/>
+    <disable_collisions link1="/finger0_0" link2="/finger0_2"/>
+    <disable_collisions link1="/finger0_0" link2="/finger1_1"/>
+    <disable_collisions link1="/finger0_0" link2="/finger1_2"/>
+    <disable_collisions link1="/finger0_0" link2="/finger2_1"/>
+    <disable_collisions link1="/finger0_0" link2="/finger2_2"/>
 
-        <disable_collisions link1="/finger1_0" link2="/finger0_1"/>
-        <disable_collisions link1="/finger1_0" link2="/finger0_2"/>
-        <disable_collisions link1="/finger1_0" link2="/finger1_1"/>
-        <disable_collisions link1="/finger1_0" link2="/finger1_2"/>
-        <disable_collisions link1="/finger1_0" link2="/finger2_1"/>
-        <disable_collisions link1="/finger1_0" link2="/finger2_2"/>
+    <disable_collisions link1="/finger1_0" link2="/finger0_1"/>
+    <disable_collisions link1="/finger1_0" link2="/finger0_2"/>
+    <disable_collisions link1="/finger1_0" link2="/finger1_1"/>
+    <disable_collisions link1="/finger1_0" link2="/finger1_2"/>
+    <disable_collisions link1="/finger1_0" link2="/finger2_1"/>
+    <disable_collisions link1="/finger1_0" link2="/finger2_2"/>
 
-        <disable_collisions link1="/finger0_1" link2="/finger0_2"/>
-        <disable_collisions link1="/finger0_1" link2="/finger1_1"/>
-        <disable_collisions link1="/finger0_1" link2="/finger1_2"/>
-        <disable_collisions link1="/finger0_1" link2="/finger2_1"/>
-        <disable_collisions link1="/finger0_1" link2="/finger2_2"/>
+    <disable_collisions link1="/finger0_1" link2="/finger0_2"/>
+    <disable_collisions link1="/finger0_1" link2="/finger1_1"/>
+    <disable_collisions link1="/finger0_1" link2="/finger1_2"/>
+    <disable_collisions link1="/finger0_1" link2="/finger2_1"/>
+    <disable_collisions link1="/finger0_1" link2="/finger2_2"/>
 
-        <disable_collisions link1="/finger0_2" link2="/finger1_1"/>
-        <disable_collisions link1="/finger0_2" link2="/finger1_2"/>
-        <disable_collisions link1="/finger0_2" link2="/finger2_1"/>
-        <disable_collisions link1="/finger0_2" link2="/finger2_2"/>
+    <disable_collisions link1="/finger0_2" link2="/finger1_1"/>
+    <disable_collisions link1="/finger0_2" link2="/finger1_2"/>
+    <disable_collisions link1="/finger0_2" link2="/finger2_1"/>
+    <disable_collisions link1="/finger0_2" link2="/finger2_2"/>
 
-        <disable_collisions link1="/finger1_1" link2="/finger1_2"/>
-        <disable_collisions link1="/finger1_1" link2="/finger2_1"/>
-        <disable_collisions link1="/finger1_1" link2="/finger2_2"/>
+    <disable_collisions link1="/finger1_1" link2="/finger1_2"/>
+    <disable_collisions link1="/finger1_1" link2="/finger2_1"/>
+    <disable_collisions link1="/finger1_1" link2="/finger2_2"/>
 
-        <disable_collisions link1="/finger1_2" link2="/finger2_1"/>
-        <disable_collisions link1="/finger1_2" link2="/finger2_2"/>
-        <disable_collisions link1="/finger2_1" link2="/finger2_2"/>
+    <disable_collisions link1="/finger1_2" link2="/finger2_1"/>
+    <disable_collisions link1="/finger1_2" link2="/finger2_2"/>
+    <disable_collisions link1="/finger2_1" link2="/finger2_2"/>
 
-        <!-- Disable collisions between the fingers and the palm. -->
-        <disable_collisions link1="/hand_base" link2="/finger1_0"/>
-        <disable_collisions link1="/hand_base" link2="/finger0_1"/>
-        <disable_collisions link1="/hand_base" link2="/finger0_2"/>
-        <disable_collisions link1="/hand_base" link2="/finger1_1"/>
-        <disable_collisions link1="/hand_base" link2="/finger1_2"/>
-        <disable_collisions link1="/hand_base" link2="/finger2_1"/>
-        <disable_collisions link1="/hand_base" link2="/finger2_2"/>
+    <!-- Disable collisions between the fingers and the palm. -->
+    <disable_collisions link1="/hand_base" link2="/finger1_0"/>
+    <disable_collisions link1="/hand_base" link2="/finger0_1"/>
+    <disable_collisions link1="/hand_base" link2="/finger0_2"/>
+    <disable_collisions link1="/hand_base" link2="/finger1_1"/>
+    <disable_collisions link1="/hand_base" link2="/finger1_2"/>
+    <disable_collisions link1="/hand_base" link2="/finger2_1"/>
+    <disable_collisions link1="/hand_base" link2="/finger2_2"/>
 
-        <!-- Sphere representation for CHOMP -->
-        <link_sphere_approximation link="/finger0_1">
-            <sphere center="0.05 -0.01 0.0" radius="0.04"/>
-        </link_sphere_approximation>
+    <!-- Sphere representation for CHOMP -->
+    <link_sphere_approximation link="/finger0_1">
+        <sphere center="0.05 -0.01 0.0" radius="0.04"/>
+    </link_sphere_approximation>
 
-        <link_sphere_approximation link="/finger1_1">
-            <sphere center="0.05 -0.01 0.0" radius="0.04"/>
-        </link_sphere_approximation>
+    <link_sphere_approximation link="/finger1_1">
+        <sphere center="0.05 -0.01 0.0" radius="0.04"/>
+    </link_sphere_approximation>
 
-        <link_sphere_approximation link="/finger2_1">
-            <sphere center="0.05 -0.01 0.0" radius="0.04"/>
-        </link_sphere_approximation>
+    <link_sphere_approximation link="/finger2_1">
+        <sphere center="0.05 -0.01 0.0" radius="0.04"/>
+    </link_sphere_approximation>
 
-        <link_sphere_approximation link="/finger0_2">
-            <sphere center="0.05 0.0 0.0" radius="0.04"/>
-        </link_sphere_approximation>
+    <link_sphere_approximation link="/finger0_2">
+        <sphere center="0.05 0.0 0.0" radius="0.04"/>
+    </link_sphere_approximation>
 
-        <link_sphere_approximation link="/finger1_2">
-            <sphere center="0.05 0.0 0.0" radius="0.04"/>
-        </link_sphere_approximation>
+    <link_sphere_approximation link="/finger1_2">
+        <sphere center="0.05 0.0 0.0" radius="0.04"/>
+    </link_sphere_approximation>
 
-        <link_sphere_approximation link="/finger2_2">
-            <sphere center="0.05 0.0 0.0" radius="0.04"/>
-        </link_sphere_approximation>
-    </xacro:macro>
+    <link_sphere_approximation link="/finger2_2">
+        <sphere center="0.05 0.0 0.0" radius="0.04"/>
+    </link_sphere_approximation>
+
 </robot>

--- a/robots/bh280_standalone.srdf.xacro
+++ b/robots/bh280_standalone.srdf.xacro
@@ -1,0 +1,84 @@
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="bh280">
+    <xacro:macro name="bh280_hand">
+        <group name="hand">
+            <link name="/hand_base"/>
+            <link name="/finger0_0"/>
+            <link name="/finger0_1"/>
+            <link name="/finger0_2"/>
+            <link name="/finger1_0"/>
+            <link name="/finger1_1"/>
+            <link name="/finger1_2"/>
+            <link name="/finger2_1"/>
+            <link name="/finger2_2"/>
+        </group>
+
+        <!-- Disable collisions between the fingers. -->
+        <disable_collisions link1="/finger0_0" link2="/finger1_0"/>
+        <disable_collisions link1="/finger0_0" link2="/finger0_1"/>
+        <disable_collisions link1="/finger0_0" link2="/finger0_2"/>
+        <disable_collisions link1="/finger0_0" link2="/finger1_1"/>
+        <disable_collisions link1="/finger0_0" link2="/finger1_2"/>
+        <disable_collisions link1="/finger0_0" link2="/finger2_1"/>
+        <disable_collisions link1="/finger0_0" link2="/finger2_2"/>
+
+        <disable_collisions link1="/finger1_0" link2="/finger0_1"/>
+        <disable_collisions link1="/finger1_0" link2="/finger0_2"/>
+        <disable_collisions link1="/finger1_0" link2="/finger1_1"/>
+        <disable_collisions link1="/finger1_0" link2="/finger1_2"/>
+        <disable_collisions link1="/finger1_0" link2="/finger2_1"/>
+        <disable_collisions link1="/finger1_0" link2="/finger2_2"/>
+
+        <disable_collisions link1="/finger0_1" link2="/finger0_2"/>
+        <disable_collisions link1="/finger0_1" link2="/finger1_1"/>
+        <disable_collisions link1="/finger0_1" link2="/finger1_2"/>
+        <disable_collisions link1="/finger0_1" link2="/finger2_1"/>
+        <disable_collisions link1="/finger0_1" link2="/finger2_2"/>
+
+        <disable_collisions link1="/finger0_2" link2="/finger1_1"/>
+        <disable_collisions link1="/finger0_2" link2="/finger1_2"/>
+        <disable_collisions link1="/finger0_2" link2="/finger2_1"/>
+        <disable_collisions link1="/finger0_2" link2="/finger2_2"/>
+
+        <disable_collisions link1="/finger1_1" link2="/finger1_2"/>
+        <disable_collisions link1="/finger1_1" link2="/finger2_1"/>
+        <disable_collisions link1="/finger1_1" link2="/finger2_2"/>
+
+        <disable_collisions link1="/finger1_2" link2="/finger2_1"/>
+        <disable_collisions link1="/finger1_2" link2="/finger2_2"/>
+        <disable_collisions link1="/finger2_1" link2="/finger2_2"/>
+
+        <!-- Disable collisions between the fingers and the palm. -->
+        <disable_collisions link1="/hand_base" link2="/finger1_0"/>
+        <disable_collisions link1="/hand_base" link2="/finger0_1"/>
+        <disable_collisions link1="/hand_base" link2="/finger0_2"/>
+        <disable_collisions link1="/hand_base" link2="/finger1_1"/>
+        <disable_collisions link1="/hand_base" link2="/finger1_2"/>
+        <disable_collisions link1="/hand_base" link2="/finger2_1"/>
+        <disable_collisions link1="/hand_base" link2="/finger2_2"/>
+
+        <!-- Sphere representation for CHOMP -->
+        <link_sphere_approximation link="/finger0_1">
+            <sphere center="0.05 -0.01 0.0" radius="0.04"/>
+        </link_sphere_approximation>
+
+        <link_sphere_approximation link="/finger1_1">
+            <sphere center="0.05 -0.01 0.0" radius="0.04"/>
+        </link_sphere_approximation>
+
+        <link_sphere_approximation link="/finger2_1">
+            <sphere center="0.05 -0.01 0.0" radius="0.04"/>
+        </link_sphere_approximation>
+
+        <link_sphere_approximation link="/finger0_2">
+            <sphere center="0.05 0.0 0.0" radius="0.04"/>
+        </link_sphere_approximation>
+
+        <link_sphere_approximation link="/finger1_2">
+            <sphere center="0.05 0.0 0.0" radius="0.04"/>
+        </link_sphere_approximation>
+
+        <link_sphere_approximation link="/finger2_2">
+            <sphere center="0.05 0.0 0.0" radius="0.04"/>
+        </link_sphere_approximation>
+    </xacro:macro>
+</robot>


### PR DESCRIPTION
This PR adds logic to build a bh280 srdf. I believe this is needed to properly specify adjacencies when loading just the hand model into OpenRAVE. Otherwise there are self collisions between the fingers and hand base.

@mkoval Is this the right way to do this? I don't think I really need the xacro. Should I just create the srdf directly and update CMakeLists to copy the file into the right location?
