### PR TITLE
xacro refactor and different hand combination models build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,4 @@ ordata/
 robots/herb.urdf
 robots/herb.srdf
 robots/bh280.urdf
-robots/bh280.urdf.xacro
 robots/wam.urdf
-robots/wam.urdf.xacro
-robots/herb_base.urdf.xacro

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,21 +4,25 @@ project(herb_description)
 find_package(catkin REQUIRED)
 catkin_package()
 
+option(BUILD_ALL_HERB_MODELS "Build all variations of the HERB models" OFF)
 
-macro(build_xacro infile outfile argstring)
+macro(build_xacro infile outfile xacro_args)
     # Call out to xacro to get dependencies
     execute_process(COMMAND ${CATKIN_ENV} rosrun xacro xacro --deps ${infile}
-    ERROR_VARIABLE _xacro_err_ignore
-    OUTPUT_VARIABLE _xacro_deps_result
-    OUTPUT_STRIP_TRAILING_WHITESPACE)
+        ERROR_VARIABLE _xacro_err_ignore
+        OUTPUT_VARIABLE _xacro_deps_result
+        OUTPUT_STRIP_TRAILING_WHITESPACE)
 
     separate_arguments(_xacro_deps_result)
+    separate_arguments(xacro_args)
 
+    # Process xacro into final output
     add_custom_command(OUTPUT ${outfile}
-    COMMENT "Generating ${outfile}"
-    COMMAND ${CATKIN_ENV} rosrun xacro xacro
-    ARGS -o ${outfile} ${infile} ${_xacro_deps_result} ${argstring}
-    DEPENDS ${infile} ${_xacro_deps_result})
+        COMMENT "Generating ${outfile}"
+        COMMAND ${CATKIN_ENV} rosrun xacro xacro
+        -o ${outfile} ${infile} ${_xacro_deps_result} ${xacro_args}
+        DEPENDS ${infile} ${_xacro_deps_result}
+        VERBATIM)
 endmacro(build_xacro)
 
 
@@ -27,7 +31,7 @@ set(BASE_OUTPUT_DIR "${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_SHARE_DESTINATION}"
 set(ROBOTS_OUTPUT_DIR "${BASE_OUTPUT_DIR}/robots")
 file(MAKE_DIRECTORY ${ROBOTS_OUTPUT_DIR})
 
-
+# Build component parts
 set(WAM_STANDALONE_URDF_XACRO "${ROBOTS_SRC_DIR}/wam_standalone.urdf.xacro")
 set(WAM_STANDALONE_URDF "${ROBOTS_OUTPUT_DIR}/wam.urdf")
 
@@ -37,21 +41,60 @@ set(BH280_STANDALONE_URDF "${ROBOTS_OUTPUT_DIR}/bh280.urdf")
 set(WAM_BH280_STANDALONE_URDF_XACRO "${ROBOTS_SRC_DIR}/wam_bh280_standalone.urdf.xacro")
 set(WAM_BH280_STANDALONE_URDF "${ROBOTS_OUTPUT_DIR}/wam_bh280.urdf")
 
+build_xacro(${WAM_STANDALONE_URDF_XACRO} ${WAM_STANDALONE_URDF} "")
+build_xacro(${BH280_STANDALONE_URDF_XACRO} ${BH280_STANDALONE_URDF} "")
+build_xacro(${WAM_BH280_STANDALONE_URDF_XACRO} ${WAM_BH280_STANDALONE_URDF} "")
+
+# HERB model matrix
+#
+# | LEFT  | RIGHT |
+# |-------|-------|
+# | BH280 | BH280 |
+# | BH280 | None  |
+# | None  | BH280 |
+# | None  | None  |
+
+# Default HERB (two BH280 hands)
 set(HERB_URDF_XACRO "${ROBOTS_SRC_DIR}/herb.urdf.xacro")
 set(HERB_URDF "${ROBOTS_OUTPUT_DIR}/herb.urdf")
 
 set(HERB_SRDF_XACRO "${ROBOTS_SRC_DIR}/herb.srdf.xacro")
 set(HERB_SRDF "${ROBOTS_OUTPUT_DIR}/herb.srdf")
 
-
-build_xacro(${WAM_STANDALONE_URDF_XACRO} ${WAM_STANDALONE_URDF} "")
-build_xacro(${BH280_STANDALONE_URDF_XACRO} ${BH280_STANDALONE_URDF} "")
-build_xacro(${WAM_BH280_STANDALONE_URDF_XACRO} ${WAM_BH280_STANDALONE_URDF} "")
-build_xacro(${HERB_URDF_XACRO} ${HERB_URDF} "")
+set(full_herb_args "left_bh280:=true" "right_bh280:=true")
+build_xacro(${HERB_URDF_XACRO} ${HERB_URDF} "${full_herb_args}")
 build_xacro(${HERB_SRDF_XACRO} ${HERB_SRDF} "")
 
+if(BUILD_ALL_HERB_MODELS)
 
-list(APPEND DESCRIPTION_FILES
+    # HERB with no right hand
+    set(HERB_NO_RIGHT_HAND_URDF "${ROBOTS_OUTPUT_DIR}/herb_no_right_hand.urdf")
+    set(HERB_NO_RIGHT_HAND_SRDF "${ROBOTS_OUTPUT_DIR}/herb_no_right_hand.srdf")
+
+    set(no_right_herb_args "left_bh280:=true" "right_bh280:=false")
+    build_xacro(${HERB_URDF_XACRO} ${HERB_NO_RIGHT_HAND_URDF} "${no_right_herb_args}")
+    build_xacro(${HERB_SRDF_XACRO} ${HERB_NO_RIGHT_HAND_SRDF} "right_hand:=false")
+
+    # HERB with no left hand
+    set(HERB_NO_LEFT_HAND_URDF "${ROBOTS_OUTPUT_DIR}/herb_no_left_hand.urdf")
+    set(HERB_NO_LEFT_HAND_SRDF "${ROBOTS_OUTPUT_DIR}/herb_no_left_hand.srdf")
+
+    set(no_left_herb_args "left_bh280:=false" "right_bh280:=true")
+    build_xacro(${HERB_URDF_XACRO} ${HERB_NO_LEFT_HAND_URDF} "${no_left_herb_args}")
+    build_xacro(${HERB_SRDF_XACRO} ${HERB_NO_LEFT_HAND_SRDF} "left_hand:=false")
+
+    # HERB with no hands
+    set(HERB_NO_HANDS_URDF "${ROBOTS_OUTPUT_DIR}/herb_no_hands.urdf")
+    set(HERB_NO_HANDS_SRDF "${ROBOTS_OUTPUT_DIR}/herb_no_hands.srdf")
+
+    set(no_right_herb_args "left_bh280:=false" "right_bh280:=false")
+    build_xacro(${HERB_URDF_XACRO} ${HERB_NO_HANDS_URDF} "${no_hands_herb_args}")
+    set(no_hands_herb_args "left_hand:=false" "right_hand:=false")
+    build_xacro(${HERB_SRDF_XACRO} ${HERB_NO_HANDS_SRDF} "${no_hands_herb_args}")
+
+endif(BUILD_ALL_HERB_MODELS)
+
+list(APPEND CORE_DESCRIPTION_FILES
   ${WAM_STANDALONE_URDF}
   ${BH280_STANDALONE_URDF}
   ${WAM_BH280_STANDALONE_URDF}
@@ -60,8 +103,23 @@ list(APPEND DESCRIPTION_FILES
 )
 
 # add target to actually cause generation
-add_custom_target(description_files ALL DEPENDS
-  ${DESCRIPTION_FILES})
+if(BUILD_ALL_HERB_MODELS)
+    list(APPEND EXTRA_DESCRIPTION_FILES
+    ${HERB_NO_LEFT_HAND_URDF}
+    ${HERB_NO_LEFT_HAND_SRDF}
+    ${HERB_NO_RIGHT_HAND_URDF}
+    ${HERB_NO_RIGHT_HAND_SRDF}
+    ${HERB_NO_HANDS_URDF}
+    ${HERB_NO_HANDS_SRDF}
+    )
+
+    add_custom_target(description_files ALL DEPENDS
+    ${CORE_DESCRIPTION_FILES}
+    ${EXTRA_DESCRIPTION_FILES})
+else()
+    add_custom_target(description_files ALL DEPENDS
+    ${CORE_DESCRIPTION_FILES})
+endif(BUILD_ALL_HERB_MODELS)
 
 install(DIRECTORY DESTINATION "${CATKIN_PACKAGE_SHARE_DESTINATION}/robots")
 install(FILES

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,172 +4,69 @@ project(herb_description)
 find_package(catkin REQUIRED)
 catkin_package()
 
+
+macro(build_xacro infile outfile argstring)
+    # Call out to xacro to get dependencies
+    execute_process(COMMAND ${CATKIN_ENV} rosrun xacro xacro --deps ${infile}
+    ERROR_VARIABLE _xacro_err_ignore
+    OUTPUT_VARIABLE _xacro_deps_result
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+    separate_arguments(_xacro_deps_result)
+
+    add_custom_command(OUTPUT ${outfile}
+    COMMENT "Generating ${outfile}"
+    COMMAND ${CATKIN_ENV} rosrun xacro xacro
+    ARGS -o ${outfile} ${infile} ${_xacro_deps_result} ${argstring}
+    DEPENDS ${infile} ${_xacro_deps_result})
+endmacro(build_xacro)
+
+
+set(ROBOTS_SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/robots")
 set(BASE_OUTPUT_DIR "${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_SHARE_DESTINATION}")
-set(COMMAND_PARAMS_POSTPROCESS "${PROJECT_SOURCE_DIR}/scripts/postprocess_params.py")
-set(COMMAND_XACRO_POSTPROCESS "${PROJECT_SOURCE_DIR}/scripts/postprocess_xacro.py")
+set(ROBOTS_OUTPUT_DIR "${BASE_OUTPUT_DIR}/robots")
+file(MAKE_DIRECTORY ${ROBOTS_OUTPUT_DIR})
 
-set(OPENRAVE_OUTPUT_DIR "${BASE_OUTPUT_DIR}/ordata")
-set(URDF_OUTPUT_DIR "${BASE_OUTPUT_DIR}/robots")
 
-file(MAKE_DIRECTORY "${URDF_OUTPUT_DIR}")
-file(MAKE_DIRECTORY "${OPENRAVE_OUTPUT_DIR}")
-file(MAKE_DIRECTORY "${OPENRAVE_OUTPUT_DIR}/robots")
+set(WAM_STANDALONE_URDF_XACRO "${ROBOTS_SRC_DIR}/wam_standalone.urdf.xacro")
+set(WAM_STANDALONE_URDF "${ROBOTS_OUTPUT_DIR}/wam.urdf")
 
-file(COPY "${PROJECT_SOURCE_DIR}/robots/wam_standalone.urdf.xacro"
-    DESTINATION "${URDF_OUTPUT_DIR}"
-)
-file(COPY "${PROJECT_SOURCE_DIR}/robots/bh280_standalone.urdf.xacro"
-    DESTINATION "${URDF_OUTPUT_DIR}"
-)
-file(COPY "${PROJECT_SOURCE_DIR}/robots/wam_bh280_standalone.urdf.xacro"
-    DESTINATION "${URDF_OUTPUT_DIR}"
-)
-file(COPY "${PROJECT_SOURCE_DIR}/robots/fixed_transforms.urdf.xacro"
-    DESTINATION "${URDF_OUTPUT_DIR}"
-)
+set(BH280_STANDALONE_URDF_XACRO "${ROBOTS_SRC_DIR}/bh280_standalone.urdf.xacro")
+set(BH280_STANDALONE_URDF "${ROBOTS_OUTPUT_DIR}/bh280.urdf")
 
-macro(xacro_expand input_path output_path)
-    add_custom_command(OUTPUT "${output_path}"
-        DEPENDS "${input_path}" ${ARGN}
-        COMMAND rosrun xacro xacro.py -o "${output_path}" "${input_path}"
-    )
-endmacro()
+set(WAM_BH280_STANDALONE_URDF_XACRO "${ROBOTS_SRC_DIR}/wam_bh280_standalone.urdf.xacro")
+set(WAM_BH280_STANDALONE_URDF "${ROBOTS_OUTPUT_DIR}/wam_bh280.urdf")
 
-macro(postprocess_urdf input_path params_path output_path)
-    add_custom_command(OUTPUT "${output_path}"
-        DEPENDS ${COMMAND_PARAMS_POSTPROCESS} "${input_path}" "${params_path}"
-        COMMAND ${COMMAND_PARAMS_POSTPROCESS} "${input_path}" "${params_path}"
-                                              "${output_path}"
-    )
-endmacro()
+set(HERB_URDF_XACRO "${ROBOTS_SRC_DIR}/herb.urdf.xacro")
+set(HERB_URDF "${ROBOTS_OUTPUT_DIR}/herb.urdf")
 
-macro(wrap_xacro input_path output_path)
-    get_filename_component(xacro_name "${output_path}" NAME_WE)
-    add_custom_command(OUTPUT "${output_path}"
-        DEPENDS ${COMMAND_XACRO_POSTPROCESS} "${input_path}"
-        COMMAND ${COMMAND_XACRO_POSTPROCESS} --swap-dae
-                --name="${xacro_name}" --package="${PROJECT_NAME}"
-                --collision_meshes=True "${input_path}" "${output_path}"
-    )
-endmacro()
+set(HERB_SRDF_XACRO "${ROBOTS_SRC_DIR}/herb.srdf.xacro")
+set(HERB_SRDF "${ROBOTS_OUTPUT_DIR}/herb.srdf")
 
-# Create a standalone WAM URDF model.
-xacro_expand("${PROJECT_SOURCE_DIR}/config/wam_params.urdf.xacro"
-             "wam_params.urdf"
-)
-postprocess_urdf("${PROJECT_SOURCE_DIR}/robots/WAM_URDF.URDF"
-                 "wam_params.urdf"
-                 "wam_raw.urdf"
-)
-wrap_xacro("wam_raw.urdf"
-           "${URDF_OUTPUT_DIR}/wam.urdf.xacro"
+
+build_xacro(${WAM_STANDALONE_URDF_XACRO} ${WAM_STANDALONE_URDF} "")
+build_xacro(${BH280_STANDALONE_URDF_XACRO} ${BH280_STANDALONE_URDF} "")
+build_xacro(${WAM_BH280_STANDALONE_URDF_XACRO} ${WAM_BH280_STANDALONE_URDF} "")
+build_xacro(${HERB_URDF_XACRO} ${HERB_URDF} "")
+build_xacro(${HERB_SRDF_XACRO} ${HERB_SRDF} "")
+
+
+list(APPEND DESCRIPTION_FILES
+  ${WAM_STANDALONE_URDF}
+  ${BH280_STANDALONE_URDF}
+  ${WAM_BH280_STANDALONE_URDF}
+  ${HERB_URDF}
+  ${HERB_SRDF}
 )
 
-xacro_expand("${URDF_OUTPUT_DIR}/wam_standalone.urdf.xacro"
-             "${URDF_OUTPUT_DIR}/wam.urdf"
-)
+# add target to actually cause generation
+add_custom_target(description_files ALL DEPENDS
+  ${DESCRIPTION_FILES})
 
-add_custom_target(wam_urdf ALL
-    DEPENDS #"${URDF_OUTPUT_DIR}/wam.urdf"
-            "${URDF_OUTPUT_DIR}/wam.urdf.xacro"
-    COMMENT "Generating WAM URDF"
-    VERBATIM
-)
+install(DIRECTORY DESTINATION "${CATKIN_PACKAGE_SHARE_DESTINATION}/robots")
+install(FILES
+  ${DESCRIPTION_FILES}
+  DESTINATION "${CATKIN_PACKAGE_SHARE_DESTINATION}/robots")
 
-# Create a standalone BarrettHand (BH280) URDF model.
-xacro_expand("${PROJECT_SOURCE_DIR}/config/bh280_params.urdf.xacro"
-             "bh280_params.urdf"
-)
-postprocess_urdf("${PROJECT_SOURCE_DIR}/robots/BHD280_URDF.URDF"
-                 "bh280_params.urdf"
-                 "bh280_raw.urdf"
-)
-wrap_xacro("bh280_raw.urdf"
-           "${URDF_OUTPUT_DIR}/bh280.urdf.xacro"
-)
-
-xacro_expand("${URDF_OUTPUT_DIR}/bh280_standalone.urdf.xacro"
-             "${URDF_OUTPUT_DIR}/bh280.urdf"
-             # Additional dependencies.
-             "${URDF_OUTPUT_DIR}/bh280.urdf.xacro"
-)
-
-add_custom_target(bh280_urdf ALL
-    DEPENDS "${URDF_OUTPUT_DIR}/bh280.urdf"
-            "${URDF_OUTPUT_DIR}/bh280.urdf.xacro"
-    COMMENT "Generating BH280 URDF"
-    VERBATIM
-)
-
-# Create a WAM + BH280 model.
-xacro_expand("${URDF_OUTPUT_DIR}/wam_bh280_standalone.urdf.xacro"
-             "${URDF_OUTPUT_DIR}/wam_bh280.urdf"
-             # Additional dependencies.
-             "${URDF_OUTPUT_DIR}/bh280.urdf.xacro"
-             "${URDF_OUTPUT_DIR}/wam.urdf.xacro"
-)
-add_custom_target(wam_bh280_urdf ALL
-    DEPENDS #"${URDF_OUTPUT_DIR}/wam_bh280.urdf"
-            "${URDF_OUTPUT_DIR}/wam_bh280_standalone.urdf.xacro"
-    COMMENT "Generating WAM+BH280 URDF"
-    VERBATIM
-)
-
-# Create the HERB URDF model.
-# TODO: We manually depend on wam.urdf.xacro and bh280.urdf.xacro because
-# xacro_add_xacro_file doesn't work properly when the included files do not
-# exist.
-xacro_expand("${PROJECT_SOURCE_DIR}/config/herb_params.urdf.xacro"
-             "herb_params.urdf")
-postprocess_urdf("${PROJECT_SOURCE_DIR}/robots/HERB_BASE_URDF.URDF"
-                 "herb_params.urdf"
-                 "herb_base_raw.urdf")
-wrap_xacro("herb_base_raw.urdf"
-           "${URDF_OUTPUT_DIR}/herb_base.urdf.xacro"
-           # Additional dependencies.
-           "${URDF_OUTPUT_DIR}/bh280.urdf.xacro"
-)
-
-if (NOT "${URDF_OUTPUT_DIR}" STREQUAL "${PROJECT_SOURCE_DIR}/robots")
-    add_custom_command(OUTPUT "${URDF_OUTPUT_DIR}/herb.urdf.xacro"
-        DEPENDS "${PROJECT_SOURCE_DIR}/robots/herb.urdf.xacro"
-                "${URDF_OUTPUT_DIR}/fixed_transforms.urdf.xacro"
-                "${URDF_OUTPUT_DIR}/herb_base.urdf.xacro"
-                "${URDF_OUTPUT_DIR}/wam.urdf.xacro"
-                "${URDF_OUTPUT_DIR}/bh280.urdf.xacro"
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different
-                "${PROJECT_SOURCE_DIR}/robots/herb.urdf.xacro"
-                "${URDF_OUTPUT_DIR}/herb.urdf.xacro"
-    )
-endif ()
-xacro_expand("${URDF_OUTPUT_DIR}/herb.urdf.xacro"
-             "${URDF_OUTPUT_DIR}/herb.urdf"
-             # Additional dependencies.
-             "${URDF_OUTPUT_DIR}/fixed_transforms.urdf.xacro"
-             "${URDF_OUTPUT_DIR}/herb_base.urdf.xacro"
-             "${URDF_OUTPUT_DIR}/bh280.urdf.xacro"
-             "${URDF_OUTPUT_DIR}/wam.urdf.xacro"
-)
-add_custom_target(herb_urdf ALL
-    DEPENDS "${URDF_OUTPUT_DIR}/herb.urdf"
-            "${URDF_OUTPUT_DIR}/herb.urdf.xacro"
-            "${URDF_OUTPUT_DIR}/herb_base.urdf.xacro"
-    COMMENT "Generating HERB URDF"
-    VERBATIM
-)
-
-# Generate the SRDF file.
-xacro_expand("${PROJECT_SOURCE_DIR}/robots/herb.srdf.xacro"
-             "${BASE_OUTPUT_DIR}/robots/herb.srdf")
-add_custom_target(herb_srdf ALL
-    DEPENDS "${URDF_OUTPUT_DIR}/herb.srdf"
-    COMMENT "Generating HERB SRDF"
-    VERBATIM
-)
-
-install(DIRECTORY "meshes"
-                  "${URDF_OUTPUT_DIR}"
-                  "${OPENRAVE_OUTPUT_DIR}"
-    DESTINATION "${CATKIN_PACKAGE_SHARE_DESTINATION}"
-    PATTERN ".svn" EXCLUDE
-)
+install(DIRECTORY meshes
+  DESTINATION "${CATKIN_PACKAGE_SHARE_DESTINATION}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,16 +68,16 @@ build_xacro(${HERB_SRDF_XACRO} ${HERB_SRDF} "")
 if(BUILD_ALL_HERB_MODELS)
 
     # HERB with no right hand
-    set(HERB_NO_RIGHT_HAND_URDF "${ROBOTS_OUTPUT_DIR}/herb_no_right_hand.urdf")
-    set(HERB_NO_RIGHT_HAND_SRDF "${ROBOTS_OUTPUT_DIR}/herb_no_right_hand.srdf")
+    set(HERB_NO_RIGHT_HAND_URDF "${ROBOTS_OUTPUT_DIR}/herb_bh280_left_no_right.urdf")
+    set(HERB_NO_RIGHT_HAND_SRDF "${ROBOTS_OUTPUT_DIR}/herb_bh280_left_no_right.srdf")
 
     set(no_right_herb_args "left_bh280:=true" "right_bh280:=false")
     build_xacro(${HERB_URDF_XACRO} ${HERB_NO_RIGHT_HAND_URDF} "${no_right_herb_args}")
     build_xacro(${HERB_SRDF_XACRO} ${HERB_NO_RIGHT_HAND_SRDF} "right_hand:=false")
 
     # HERB with no left hand
-    set(HERB_NO_LEFT_HAND_URDF "${ROBOTS_OUTPUT_DIR}/herb_no_left_hand.urdf")
-    set(HERB_NO_LEFT_HAND_SRDF "${ROBOTS_OUTPUT_DIR}/herb_no_left_hand.srdf")
+    set(HERB_NO_LEFT_HAND_URDF "${ROBOTS_OUTPUT_DIR}/herb_no_left_bh280_right.urdf")
+    set(HERB_NO_LEFT_HAND_SRDF "${ROBOTS_OUTPUT_DIR}/herb_no_left_bh280_right.srdf")
 
     set(no_left_herb_args "left_bh280:=false" "right_bh280:=true")
     build_xacro(${HERB_URDF_XACRO} ${HERB_NO_LEFT_HAND_URDF} "${no_left_herb_args}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,24 +6,33 @@ catkin_package()
 
 option(BUILD_ALL_HERB_MODELS "Build all variations of the HERB models" OFF)
 
-macro(build_xacro infile outfile xacro_args)
-    # Call out to xacro to get dependencies
-    execute_process(COMMAND ${CATKIN_ENV} rosrun xacro xacro --deps ${infile}
-        ERROR_VARIABLE _xacro_err_ignore
-        OUTPUT_VARIABLE _xacro_deps_result
-        OUTPUT_STRIP_TRAILING_WHITESPACE)
+function(build_xacro infile outfile xacro_args)
+  # Call out to xacro to get dependencies
+  execute_process(COMMAND ${CATKIN_ENV} rosrun xacro xacro --deps "${infile}"
+    ERROR_VARIABLE _xacro_err_ignore
+    OUTPUT_VARIABLE _xacro_deps_result
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
 
-    separate_arguments(_xacro_deps_result)
-    separate_arguments(xacro_args)
+  separate_arguments(_xacro_deps_result)
+  separate_arguments(xacro_args)
 
-    # Process xacro into final output
-    add_custom_command(OUTPUT ${outfile}
-        COMMENT "Generating ${outfile}"
-        COMMAND ${CATKIN_ENV} rosrun xacro xacro
-        -o ${outfile} ${infile} ${_xacro_deps_result} ${xacro_args}
-        DEPENDS ${infile} ${_xacro_deps_result}
-        VERBATIM)
-endmacro(build_xacro)
+  # Process xacro into final output
+  add_custom_command(OUTPUT "${outfile}"
+    COMMENT "Generating ${outfile}"
+    COMMAND ${CATKIN_ENV} rosrun xacro xacro
+    -o "${outfile}" "${infile}" ${_xacro_deps_result} ${xacro_args}
+    DEPENDS "${infile}" ${_xacro_deps_result}
+    VERBATIM)
+endfunction(build_xacro)
+
+macro(append_hand_flags hand hand_option urdf_args srdf_args)
+  if(${hand_option} STREQUAL "bh280")
+    list(APPEND ${urdf_args} "${hand}_bh280:=true")
+  endif()
+  if(NOT ${hand_option} STREQUAL "no")
+    list(APPEND ${srdf_args} "${hand}_hand:=true")
+  endif()
+endmacro(append_hand_flags)
 
 
 set(ROBOTS_SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/robots")
@@ -54,6 +63,8 @@ build_xacro(${WAM_BH280_STANDALONE_URDF_XACRO} ${WAM_BH280_STANDALONE_URDF} "")
 # | None  | BH280 |
 # | None  | None  |
 
+set(HERB_HAND_OPTIONS "bh280" "no")
+
 # Default HERB (two BH280 hands)
 set(HERB_URDF_XACRO "${ROBOTS_SRC_DIR}/herb.urdf.xacro")
 set(HERB_URDF "${ROBOTS_OUTPUT_DIR}/herb.urdf")
@@ -61,38 +72,10 @@ set(HERB_URDF "${ROBOTS_OUTPUT_DIR}/herb.urdf")
 set(HERB_SRDF_XACRO "${ROBOTS_SRC_DIR}/herb.srdf.xacro")
 set(HERB_SRDF "${ROBOTS_OUTPUT_DIR}/herb.srdf")
 
-set(full_herb_args "left_bh280:=true" "right_bh280:=true")
-build_xacro(${HERB_URDF_XACRO} ${HERB_URDF} "${full_herb_args}")
-build_xacro(${HERB_SRDF_XACRO} ${HERB_SRDF} "")
-
-if(BUILD_ALL_HERB_MODELS)
-
-    # HERB with no right hand
-    set(HERB_NO_RIGHT_HAND_URDF "${ROBOTS_OUTPUT_DIR}/herb_bh280_left_no_right.urdf")
-    set(HERB_NO_RIGHT_HAND_SRDF "${ROBOTS_OUTPUT_DIR}/herb_bh280_left_no_right.srdf")
-
-    set(no_right_herb_args "left_bh280:=true" "right_bh280:=false")
-    build_xacro(${HERB_URDF_XACRO} ${HERB_NO_RIGHT_HAND_URDF} "${no_right_herb_args}")
-    build_xacro(${HERB_SRDF_XACRO} ${HERB_NO_RIGHT_HAND_SRDF} "right_hand:=false")
-
-    # HERB with no left hand
-    set(HERB_NO_LEFT_HAND_URDF "${ROBOTS_OUTPUT_DIR}/herb_no_left_bh280_right.urdf")
-    set(HERB_NO_LEFT_HAND_SRDF "${ROBOTS_OUTPUT_DIR}/herb_no_left_bh280_right.srdf")
-
-    set(no_left_herb_args "left_bh280:=false" "right_bh280:=true")
-    build_xacro(${HERB_URDF_XACRO} ${HERB_NO_LEFT_HAND_URDF} "${no_left_herb_args}")
-    build_xacro(${HERB_SRDF_XACRO} ${HERB_NO_LEFT_HAND_SRDF} "left_hand:=false")
-
-    # HERB with no hands
-    set(HERB_NO_HANDS_URDF "${ROBOTS_OUTPUT_DIR}/herb_no_left_no_right.urdf")
-    set(HERB_NO_HANDS_SRDF "${ROBOTS_OUTPUT_DIR}/herb_no_left_no_right.srdf")
-
-    set(no_right_herb_args "left_bh280:=false" "right_bh280:=false")
-    build_xacro(${HERB_URDF_XACRO} ${HERB_NO_HANDS_URDF} "${no_hands_herb_args}")
-    set(no_hands_herb_args "left_hand:=false" "right_hand:=false")
-    build_xacro(${HERB_SRDF_XACRO} ${HERB_NO_HANDS_SRDF} "${no_hands_herb_args}")
-
-endif(BUILD_ALL_HERB_MODELS)
+set(FULL_HERB_URDF_ARGS "left_bh280:=true" "right_bh280:=true")
+build_xacro(${HERB_URDF_XACRO} ${HERB_URDF} "${FULL_HERB_URDF_ARGS}")
+set(FULL_HERB_SRDF_ARGS "left_hand:=true" "right_hand:=true")
+build_xacro(${HERB_SRDF_XACRO} ${HERB_SRDF} "${FULL_HERB_SRDF_ARGS}")
 
 list(APPEND CORE_DESCRIPTION_FILES
   ${WAM_STANDALONE_URDF}
@@ -100,25 +83,49 @@ list(APPEND CORE_DESCRIPTION_FILES
   ${WAM_BH280_STANDALONE_URDF}
   ${HERB_URDF}
   ${HERB_SRDF}
-)
+  )
 
-# add target to actually cause generation
+
 if(BUILD_ALL_HERB_MODELS)
-    list(APPEND EXTRA_DESCRIPTION_FILES
-    ${HERB_NO_LEFT_HAND_URDF}
-    ${HERB_NO_LEFT_HAND_SRDF}
-    ${HERB_NO_RIGHT_HAND_URDF}
-    ${HERB_NO_RIGHT_HAND_SRDF}
-    ${HERB_NO_HANDS_URDF}
-    ${HERB_NO_HANDS_SRDF}
-    )
+  set(EXTRA_DESCRIPTION_FILES)
 
-    add_custom_target(description_files ALL DEPENDS
+  # Generate combinatorial hand option models
+  foreach(LEFT_HAND ${HERB_HAND_OPTIONS})
+    foreach(RIGHT_HAND ${HERB_HAND_OPTIONS})
+
+      # default configure is named differently and handled outside loop
+      if(NOT (${LEFT_HAND} STREQUAL "bh280" AND ${RIGHT_HAND} STREQUAL "bh280"))
+        set(HERB_URDF_OUTPUT "${ROBOTS_OUTPUT_DIR}/herb_${LEFT_HAND}_left_${RIGHT_HAND}_right.urdf")
+        set(HERB_SRDF_OUTPUT "${ROBOTS_OUTPUT_DIR}/herb_${LEFT_HAND}_left_${RIGHT_HAND}_right.srdf")
+
+        set(HERB_URDF_ARGS)
+        set(HERB_SRDF_ARGS)
+
+        append_hand_flags(left LEFT_HAND HERB_URDF_ARGS HERB_SRDF_ARGS)
+        append_hand_flags(right RIGHT_HAND HERB_URDF_ARGS HERB_SRDF_ARGS)
+
+        build_xacro(${HERB_URDF_XACRO} ${HERB_URDF_OUTPUT} "${HERB_URDF_ARGS}")
+        build_xacro(${HERB_SRDF_XACRO} ${HERB_SRDF_OUTPUT} "${HERB_SRDF_ARGS}")
+
+        list(APPEND EXTRA_DESCRIPTION_FILES
+          ${HERB_URDF_OUTPUT}
+          ${HERB_SRDF_OUTPUT})
+      endif()
+
+    endforeach(RIGHT_HAND)
+  endforeach(LEFT_HAND)
+
+  # add target to actually cause generation
+  add_custom_target(description_files ALL DEPENDS
     ${CORE_DESCRIPTION_FILES}
     ${EXTRA_DESCRIPTION_FILES})
+
 else()
-    add_custom_target(description_files ALL DEPENDS
+
+  # add target to actually cause generation
+  add_custom_target(description_files ALL DEPENDS
     ${CORE_DESCRIPTION_FILES})
+
 endif(BUILD_ALL_HERB_MODELS)
 
 install(DIRECTORY DESTINATION "${CATKIN_PACKAGE_SHARE_DESTINATION}/robots")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,8 +84,8 @@ if(BUILD_ALL_HERB_MODELS)
     build_xacro(${HERB_SRDF_XACRO} ${HERB_NO_LEFT_HAND_SRDF} "left_hand:=false")
 
     # HERB with no hands
-    set(HERB_NO_HANDS_URDF "${ROBOTS_OUTPUT_DIR}/herb_no_hands.urdf")
-    set(HERB_NO_HANDS_SRDF "${ROBOTS_OUTPUT_DIR}/herb_no_hands.srdf")
+    set(HERB_NO_HANDS_URDF "${ROBOTS_OUTPUT_DIR}/herb_no_left_no_right.urdf")
+    set(HERB_NO_HANDS_SRDF "${ROBOTS_OUTPUT_DIR}/herb_no_left_no_right.srdf")
 
     set(no_right_herb_args "left_bh280:=false" "right_bh280:=false")
     build_xacro(${HERB_URDF_XACRO} ${HERB_NO_HANDS_URDF} "${no_hands_herb_args}")

--- a/package.xml
+++ b/package.xml
@@ -14,8 +14,5 @@
     <license>BSD</license>
     <buildtool_depend>catkin</buildtool_depend>
     <buildtool_depend>xacro</buildtool_depend>
-    <buildtool_depend>python-argparse</buildtool_depend>
-    <buildtool_depend>python-lxml</buildtool_depend>
-    <buildtool_depend>python-simplejson</buildtool_depend>
     <buildtool_depend>rosbash</buildtool_depend>
 </package>

--- a/robots/bh280.urdf.xacro
+++ b/robots/bh280.urdf.xacro
@@ -1,0 +1,334 @@
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="bh280">
+  <xacro:macro name="bh280" params="prefix">
+    <link name="${prefix}/hand_base">
+      <visual>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <mesh filename="package://herb_description/meshes/hand_base.dae"/>
+        </geometry>
+        <material name="">
+          <color rgba="0.752941176470588 0.752941176470588 0.752941176470588 1"/>
+        </material>
+      </visual>
+      <geometry_group name="fine_collision">
+        <origin rpy="0 0 0" xyz="0 0 0"/>
+        <geometry>
+          <mesh filename="package://herb_description/meshes/hand_base.STL"/>
+        </geometry>
+      </geometry_group>
+      <inertial>
+        <origin xyz="5.0019e-005 -0.0044561 0.037268"/>
+        <mass value="0.60858"/>
+        <inertia
+            ixx="0.0006986" ixy="2.7577e-007" ixz="-7.8138e-007"
+            iyx="0.0000000" iyy="0.00050354"  iyz="-6.44e-005"
+            izx="0.0000000" izy="0.00000000"  izz="0.00062253"/>
+      </inertial>
+      <collision>
+        <geometry>
+          <mesh filename="package://herb_description/meshes/hand_base_collision.STL"/>
+        </geometry>
+      </collision>
+    </link>
+    <link name="${prefix}/finger0_0">
+      <visual>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <mesh filename="package://herb_description/meshes/finger0_0.dae"/>
+        </geometry>
+        <material name="">
+          <color rgba="0.752941176470588 0.752941176470588 0.752941176470588 1"/>
+        </material>
+      </visual>
+      <geometry_group name="fine_collision">
+        <origin rpy="0 0 0" xyz="0 0 0"/>
+        <geometry>
+          <mesh filename="package://herb_description/meshes/finger0_0.STL"/>
+        </geometry>
+      </geometry_group>
+      <inertial>
+        <origin xyz="0.030616 -7.3219e-005 -0.011201"/>
+        <mass value="0.14109"/>
+        <inertia
+            ixx="2.0672e-005" ixy="2.6024e-007" ixz="6.3481e-006"
+            iyx="0.000000000" iyy="7.4105e-005" iyz="1.7118e-008"
+            izx="0.000000000" izy="0.000000000" izz="6.8207e-005"/>
+      </inertial>
+      <collision>
+        <geometry>
+          <mesh filename="package://herb_description/meshes/finger0_0_collision.STL"/>
+        </geometry>
+      </collision>
+    </link>
+    <joint name="${prefix}/j00" type="revolute">
+      <origin xyz="-0.025 0 0.0754000000000003" rpy="-9.27906974436996E-30 -2.56739074444568E-16 -1.5707963267949"/>
+      <parent link="${prefix}/hand_base"/>
+      <child link="${prefix}/finger0_0"/>
+      <axis xyz="0 0 -1"/>
+      <limit effort="0" lower="0" upper="3.14159265359" velocity="2.0"/>
+    </joint>
+    <link name="${prefix}/finger0_1">
+      <visual>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <mesh filename="package://herb_description/meshes/finger0_1.dae"/>
+        </geometry>
+        <material name="">
+          <color rgba="0.752941176470588 0.752941176470588 0.752941176470588 1"/>
+        </material>
+      </visual>
+      <geometry_group name="fine_collision">
+        <origin rpy="0 0 0" xyz="0 0 0"/>
+        <geometry>
+          <mesh filename="package://herb_description/meshes/finger0_1.STL"/>
+        </geometry>
+      </geometry_group>
+      <inertial>
+        <origin xyz="0.023133 0.00078642 0.00052792"/>
+        <mass value="0.062139"/>
+        <inertia
+            ixx="4.8162e-006" ixy="5.7981e-007" ixz="-7.2483e-007"
+            iyx="0.000000000" iyy="4.3317e-005" iyz="-2.6653e-009"
+            izx="0.000000000" izy="0.000000000" izz="4.4441e-005"/>
+      </inertial>
+      <collision>
+        <geometry>
+          <mesh filename="package://herb_description/meshes/finger0_1_collision.STL"/>
+        </geometry>
+      </collision>
+    </link>
+    <joint name="${prefix}/j01" type="revolute">
+      <origin xyz="0.0500000000000007 0.000799999999999971 0" rpy="1.5707963267949 0 0"/>
+      <parent link="${prefix}/finger0_0"/>
+      <child link="${prefix}/finger0_1"/>
+      <axis xyz="0 0 1"/>
+      <limit effort="0" lower="0" upper="2.44346095279" velocity="2.0"/>
+    </joint>
+    <link name="${prefix}/finger0_2">
+      <visual>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <mesh filename="package://herb_description/meshes/finger0_2.dae"/>
+        </geometry>
+        <material name="">
+          <color rgba="0.898039215686275 0.917647058823529 0.929411764705882 1"/>
+        </material>
+      </visual>
+      <geometry_group name="fine_collision">
+        <origin rpy="0 0 0" xyz="0 0 0"/>
+        <geometry>
+          <mesh filename="package://herb_description/meshes/finger0_2.STL"/>
+        </geometry>
+      </geometry_group>
+      <inertial>
+        <origin xyz="0.02295 0.0010739 0.00041752"/>
+        <mass value="0.04166"/>
+        <inertia
+            ixx="3.1199e-006" ixy="4.5115e-007" ixz="-2.9813e-007"
+            iyx="0.000000000" iyy="1.6948e-005" iyz="-1.8635e-008"
+            izx="0.000000000" izy="0.000000000" izz="1.5809e-005"/>
+      </inertial>
+      <collision>
+        <geometry>
+          <mesh filename="package://herb_description/meshes/finger0_2_collision.STL"/>
+        </geometry>
+      </collision>
+    </link>
+    <joint name="${prefix}/j02" type="revolute">
+      <origin xyz="0.069935684739622 0.00300000000000003 0.000200000000006934" rpy="-3.77533479986348E-14 -4.45260733378639E-14 0.698131700822416"/>
+      <parent link="${prefix}/finger0_1"/>
+      <child link="${prefix}/finger0_2"/>
+      <axis xyz="0 0 1"/>
+      <limit effort="0" lower="0" upper="0.837758040957" velocity="2.0"/>
+      <mimic joint="${prefix}/j01" multiplier="0.321428571429" offset="0.0"/>
+    </joint>
+    <link name="${prefix}/finger1_0">
+      <visual>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <mesh filename="package://herb_description/meshes/finger1_0.dae"/>
+        </geometry>
+        <material name="">
+          <color rgba="0.752941176470588 0.752941176470588 0.752941176470588 1"/>
+        </material>
+      </visual>
+      <geometry_group name="fine_collision">
+        <origin rpy="0 0 0" xyz="0 0 0"/>
+        <geometry>
+          <mesh filename="package://herb_description/meshes/finger1_0.STL"/>
+        </geometry>
+      </geometry_group>
+      <inertial>
+        <origin xyz="0.030616 -7.3219e-005 -0.011201"/>
+        <mass value="0.14109"/>
+        <inertia
+            ixx="2.0672e-005" ixy="2.6024e-007" ixz="6.3481e-006"
+            iyx="0.000000000" iyy="7.4105e-005" iyz="1.7118e-008"
+            izx="0.000000000" izy="0.000000000" izz="6.8207e-005"/>
+      </inertial>
+      <collision>
+        <geometry>
+          <mesh filename="package://herb_description/meshes/finger1_0_collision.STL"/>
+        </geometry>
+      </collision>
+    </link>
+    <joint name="${prefix}/j10" type="revolute">
+      <origin xyz="0.025 0 0.0754" rpy="-9.2871E-30 -0.0058448 -1.5708"/>
+      <parent link="${prefix}/hand_base"/>
+      <child link="${prefix}/finger1_0"/>
+      <axis xyz="0.0058448 0 0.99998"/>
+      <limit effort="0" lower="0" upper="3.14159265359" velocity="2.0"/>
+      <mimic joint="${prefix}/j00" multiplier="1" offset="0"/>
+    </joint>
+    <link name="${prefix}/finger1_1">
+      <visual>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <mesh filename="package://herb_description/meshes/finger1_1.dae"/>
+        </geometry>
+        <material name="">
+          <color rgba="0.752941176470588 0.752941176470588 0.752941176470588 1"/>
+        </material>
+      </visual>
+      <geometry_group name="fine_collision">
+        <origin rpy="0 0 0" xyz="0 0 0"/>
+        <geometry>
+          <mesh filename="package://herb_description/meshes/finger1_1.STL"/>
+        </geometry>
+      </geometry_group>
+      <inertial>
+        <origin xyz="0.023133 0.00078642 0.00052792"/>
+        <mass value="0.062139"/>
+        <inertia
+            ixx="4.8162e-006" ixy="5.7981e-007" ixz="-7.2483e-007"
+            iyx="0.000000000" iyy="4.3317e-005" iyz="-2.6653e-009"
+            izx="0.000000000" izy="0.000000000" izz="4.4441e-005"/>
+      </inertial>
+      <collision>
+        <geometry>
+          <mesh filename="package://herb_description/meshes/finger1_1_collision.STL"/>
+        </geometry>
+      </collision>
+    </link>
+    <joint name="${prefix}/j11" type="revolute">
+      <origin xyz="0.0499991459461259 0.000799999999999367 -0.000292240753933679" rpy="1.5707963267949 0 -4.93038065763132E-32"/>
+      <parent link="${prefix}/finger1_0"/>
+      <child link="${prefix}/finger1_1"/>
+      <axis xyz="0 0 1"/>
+      <limit effort="0" lower="0" upper="2.44346095279" velocity="2.0"/>
+    </joint>
+    <link name="${prefix}/finger1_2">
+      <visual>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <mesh filename="package://herb_description/meshes/finger1_2.dae"/>
+        </geometry>
+        <material name="">
+          <color rgba="0.898039215686275 0.917647058823529 0.929411764705882 1"/>
+        </material>
+      </visual>
+      <geometry_group name="fine_collision">
+        <origin rpy="0 0 0" xyz="0 0 0"/>
+        <geometry>
+          <mesh filename="package://herb_description/meshes/finger1_2.STL"/>
+        </geometry>
+      </geometry_group>
+      <inertial>
+        <origin xyz="0.02295 0.0010739 0.00041752"/>
+        <mass value="0.04166"/>
+        <inertia
+            ixx="3.1199e-006" ixy="4.5115e-007" ixz="-2.9813e-007"
+            iyx="0.000000000" iyy="1.6948e-005" iyz="-1.8635e-008"
+            izx="0.000000000" izy="0.000000000" izz="1.5809e-005"/>
+      </inertial>
+      <collision>
+        <geometry>
+          <mesh filename="package://herb_description/meshes/finger1_2_collision.STL"/>
+        </geometry>
+      </collision>
+    </link>
+    <joint name="${prefix}/j12" type="revolute">
+      <origin xyz="0.0699356847396015 0.00300000000003377 0.000199999999999378" rpy="1.95799899548702E-16 2.29686057908074E-16 0.700079983587682"/>
+      <parent link="${prefix}/finger1_1"/>
+      <child link="${prefix}/finger1_2"/>
+      <axis xyz="0 0 1"/>
+      <limit effort="0" lower="0" upper="0.837758040957" velocity="2.0"/>
+      <mimic joint="${prefix}/j11" multiplier="0.321428571429" offset="0.0"/>
+    </joint>
+    <link name="${prefix}/finger2_1">
+      <visual>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <mesh filename="package://herb_description/meshes/finger2_1.dae"/>
+        </geometry>
+        <material name="">
+          <color rgba="0.752941176470588 0.752941176470588 0.752941176470588 1"/>
+        </material>
+      </visual>
+      <geometry_group name="fine_collision">
+        <origin rpy="0 0 0" xyz="0 0 0"/>
+        <geometry>
+          <mesh filename="package://herb_description/meshes/finger2_1.STL"/>
+        </geometry>
+      </geometry_group>
+      <inertial>
+        <origin xyz="0.023133 0.00078642 0.00052792"/>
+        <mass value="0.062139"/>
+        <inertia
+            ixx="4.8162e-006" ixy="5.7981e-007" ixz="-7.2483e-007"
+            iyx="0.000000000" iyy="4.3317e-005" iyz="-2.6653e-009"
+            izx="0.000000000" izy="0.000000000" izz="4.4441e-005"/>
+      </inertial>
+      <collision>
+        <geometry>
+          <mesh filename="package://herb_description/meshes/finger2_1_collision.STL"/>
+        </geometry>
+      </collision>
+    </link>
+    <joint name="${prefix}/j21" type="revolute">
+      <origin xyz="-0.000799999999999992 0.05 0.0754000000000003" rpy="1.5707963267949 2.77555756156289E-17 1.5707963267949"/>
+      <parent link="${prefix}/hand_base"/>
+      <child link="${prefix}/finger2_1"/>
+      <axis xyz="0 0 1"/>
+      <limit effort="0" lower="0" upper="2.44346095279" velocity="2.0"/>
+    </joint>
+    <link name="${prefix}/finger2_2">
+      <visual>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <mesh filename="package://herb_description/meshes/finger2_2.dae"/>
+        </geometry>
+        <material name="">
+          <color rgba="0.898039215686275 0.917647058823529 0.929411764705882 1"/>
+        </material>
+      </visual>
+      <geometry_group name="fine_collision">
+        <origin rpy="0 0 0" xyz="0 0 0"/>
+        <geometry>
+          <mesh filename="package://herb_description/meshes/finger2_2.STL"/>
+        </geometry>
+      </geometry_group>
+      <inertial>
+        <origin xyz="0.02295 0.0010739 0.00041752"/>
+        <mass value="0.04166"/>
+        <inertia
+            ixx="3.1199e-006" ixy="4.5115e-007" ixz="-2.9813e-007"
+            iyx="0.000000000" iyy="1.6948e-005" iyz="-1.8635e-008"
+            izx="0.000000000" izy="0.000000000" izz="1.5809e-005"/>
+      </inertial>
+      <collision>
+        <geometry>
+          <mesh filename="package://herb_description/meshes/finger2_2_collision.STL"/>
+        </geometry>
+      </collision>
+    </link>
+    <joint name="${prefix}/j22" type="revolute">
+      <origin xyz="0.0699356847396236 0.00300000000000011 0.000199999999999993" rpy="5.6276902721421E-16 5.75421399737176E-16 0.698131700797743"/>
+      <parent link="${prefix}/finger2_1"/>
+      <child link="${prefix}/finger2_2"/>
+      <axis xyz="0 0 1"/>
+      <limit effort="0" lower="0" upper="0.837758040957" velocity="2.0"/>
+      <mimic joint="${prefix}/j21" multiplier="0.321428571429" offset="0.0"/>
+    </joint>
+  </xacro:macro>
+</robot>

--- a/robots/herb.srdf.xacro
+++ b/robots/herb.srdf.xacro
@@ -176,10 +176,10 @@
   <xacro:wam_manipulator prefix="right"/>
 
   <xacro:if value="$(arg left_hand)">
-    <xacro:barrett_endeffector prefix="left"/>
+    <xacro:barretthand_endeffector prefix="left"/>
   </xacro:if>
   <xacro:if value="$(arg right_hand)">
-    <xacro:barrett_endeffector prefix="right"/>
+    <xacro:barretthand_endeffector prefix="right"/>
   </xacro:if>
 
   <xacro:pantilt name="head"/>

--- a/robots/herb.srdf.xacro
+++ b/robots/herb.srdf.xacro
@@ -166,8 +166,11 @@
                   parent_link="/${name}/wam2" parent_group="${name}"/>
   </xacro:macro>
 
-  <xacro:arg name="left_hand" default="true"/>
-  <xacro:arg name="right_hand" default="true"/>
+  <!-- hand arguments should all default to false to make argument passing sane -->
+  <!-- NOTE: if we use kinematically distinct hands from the BarrettHand
+       we will need more fine-grained arguments -->
+  <xacro:arg name="left_hand" default="false"/>
+  <xacro:arg name="right_hand" default="false"/>
 
   <xacro:wam_manipulator prefix="left"/>
   <xacro:wam_manipulator prefix="right"/>

--- a/robots/herb.srdf.xacro
+++ b/robots/herb.srdf.xacro
@@ -1,363 +1,190 @@
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="herb">
-    <xacro:macro name="wam_bh280_manipulator" params="prefix">
-        <group name="${prefix}">
-            <chain base_link="/${prefix}/wam_base" tip_link="/${prefix}/wam7"/>
-        </group>
 
-        <group name="${prefix}_hand">
-            <link name="/${prefix}/hand_base"/>
-            <link name="/${prefix}/finger0_0"/>
-            <link name="/${prefix}/finger0_1"/>
-            <link name="/${prefix}/finger0_2"/>
-            <link name="/${prefix}/finger1_0"/>
-            <link name="/${prefix}/finger1_1"/>
-            <link name="/${prefix}/finger1_2"/>
-            <link name="/${prefix}/finger2_1"/>
-            <link name="/${prefix}/finger2_2"/>
-        </group>
+  <xacro:macro name="wam_manipulator" params="prefix">
+    <group name="${prefix}">
+      <chain base_link="/${prefix}/wam_base" tip_link="/${prefix}/wam7"/>
+    </group>
 
-        <end_effector name="${prefix}_hand" group="${prefix}_hand"
-                      parent_link="/${prefix}/wam7" parent_group="${prefix}"/>
+    <!-- WAM self collisions -->
+    <disable_collisions link1="/${prefix}/wam1" link2="/${prefix}/wam3"/>
+    <disable_collisions link1="/${prefix}/wam4" link2="/${prefix}/wam6"/>
+    <disable_collisions link1="/${prefix}/wam4" link2="/${prefix}/wam7"/>
+    <disable_collisions link1="/${prefix}/wam5" link2="/${prefix}/wam7"/>
 
-        <!-- Disable collisions between the fingers. -->
-        <disable_collisions link1="/${prefix}/finger0_0" link2="/${prefix}/finger1_0"/>
-        <disable_collisions link1="/${prefix}/finger0_0" link2="/${prefix}/finger0_1"/>
-        <disable_collisions link1="/${prefix}/finger0_0" link2="/${prefix}/finger0_2"/>
-        <disable_collisions link1="/${prefix}/finger0_0" link2="/${prefix}/finger1_1"/>
-        <disable_collisions link1="/${prefix}/finger0_0" link2="/${prefix}/finger1_2"/>
-        <disable_collisions link1="/${prefix}/finger0_0" link2="/${prefix}/finger2_1"/>
-        <disable_collisions link1="/${prefix}/finger0_0" link2="/${prefix}/finger2_2"/>
+    <!-- Sphere representation for CHOMP -->
+    <link_sphere_approximation link="/${prefix}/wam_base">
+      <sphere center="0.0 0.0 0.0" radius="0.15"/>
+    </link_sphere_approximation>
 
-        <disable_collisions link1="/${prefix}/finger1_0" link2="/${prefix}/finger0_1"/>
-        <disable_collisions link1="/${prefix}/finger1_0" link2="/${prefix}/finger0_2"/>
-        <disable_collisions link1="/${prefix}/finger1_0" link2="/${prefix}/finger1_1"/>
-        <disable_collisions link1="/${prefix}/finger1_0" link2="/${prefix}/finger1_2"/>
-        <disable_collisions link1="/${prefix}/finger1_0" link2="/${prefix}/finger2_1"/>
-        <disable_collisions link1="/${prefix}/finger1_0" link2="/${prefix}/finger2_2"/>
+    <link_sphere_approximation link="/${prefix}/wam1">
+      <sphere center="0 0 0" radius="0"/>
+    </link_sphere_approximation>
 
-        <disable_collisions link1="/${prefix}/finger0_1" link2="/${prefix}/finger0_2"/>
-        <disable_collisions link1="/${prefix}/finger0_1" link2="/${prefix}/finger1_1"/>
-        <disable_collisions link1="/${prefix}/finger0_1" link2="/${prefix}/finger1_2"/>
-        <disable_collisions link1="/${prefix}/finger0_1" link2="/${prefix}/finger2_1"/>
-        <disable_collisions link1="/${prefix}/finger0_1" link2="/${prefix}/finger2_2"/>
+    <link_sphere_approximation link="/${prefix}/wam2">
+      <sphere center="0.0 -0.2 0.0" radius="0.06"/>
+      <sphere center="0.0 -0.3 0.0" radius="0.06"/>
+      <sphere center="0.0 -0.4 0.0" radius="0.06"/>
+      <sphere center="0.0 -0.5 0.0" radius="0.06"/>
+    </link_sphere_approximation>
 
-        <disable_collisions link1="/${prefix}/finger0_2" link2="/${prefix}/finger1_1"/>
-        <disable_collisions link1="/${prefix}/finger0_2" link2="/${prefix}/finger1_2"/>
-        <disable_collisions link1="/${prefix}/finger0_2" link2="/${prefix}/finger2_1"/>
-        <disable_collisions link1="/${prefix}/finger0_2" link2="/${prefix}/finger2_2"/>
+    <link_sphere_approximation link="/${prefix}/wam3">
+      <sphere center=" 0.045 0.0 0.55" radius="0.06"/>
+    </link_sphere_approximation>
 
-        <disable_collisions link1="/${prefix}/finger1_1" link2="/${prefix}/finger1_2"/>
-        <disable_collisions link1="/${prefix}/finger1_1" link2="/${prefix}/finger2_1"/>
-        <disable_collisions link1="/${prefix}/finger1_1" link2="/${prefix}/finger2_2"/>
+    <link_sphere_approximation link="/${prefix}/wam4">
+      <sphere center="-0.045 -0.2  0.0" radius="0.06"/>
+      <sphere center="-0.045 -0.1  0.0" radius="0.06"/>
+      <sphere center="-0.045 -0.3  0.0" radius="0.06"/>
+    </link_sphere_approximation>
 
-        <disable_collisions link1="/${prefix}/finger1_2" link2="/${prefix}/finger2_1"/>
-        <disable_collisions link1="/${prefix}/finger1_2" link2="/${prefix}/finger2_2"/>
-        <disable_collisions link1="/${prefix}/finger2_1" link2="/${prefix}/finger2_2"/>
+    <link_sphere_approximation link="/${prefix}/wam5">
+      <sphere center="0 0 0" radius="0"/>
+    </link_sphere_approximation>
 
-        <!-- Disable collisions between the fingers and the palm. -->
-        <disable_collisions link1="/${prefix}/hand_base" link2="/${prefix}/finger1_0"/>
-        <disable_collisions link1="/${prefix}/hand_base" link2="/${prefix}/finger0_1"/>
-        <disable_collisions link1="/${prefix}/hand_base" link2="/${prefix}/finger0_2"/>
-        <disable_collisions link1="/${prefix}/hand_base" link2="/${prefix}/finger1_1"/>
-        <disable_collisions link1="/${prefix}/hand_base" link2="/${prefix}/finger1_2"/>
-        <disable_collisions link1="/${prefix}/hand_base" link2="/${prefix}/finger2_1"/>
-        <disable_collisions link1="/${prefix}/hand_base" link2="/${prefix}/finger2_2"/>
+    <link_sphere_approximation link="/${prefix}/wam6">
+      <sphere center="0.0 -0.1 0.0" radius="0.06"/>
+    </link_sphere_approximation>
 
-        <!-- WAM self collisions -->
-        <disable_collisions link1="/${prefix}/wam1" link2="/${prefix}/wam3"/>
-        <disable_collisions link1="/${prefix}/wam4" link2="/${prefix}/wam6"/>
-        <disable_collisions link1="/${prefix}/wam4" link2="/${prefix}/wam7"/>
-        <disable_collisions link1="/${prefix}/wam5" link2="/${prefix}/wam7"/>
-        <disable_collisions link1="/${prefix}/wam6" link2="/${prefix}/hand_base"/>
+    <!-- FIXME: Shouldn't wam7 have a sphere? -->
+    <link_sphere_approximation link="/${prefix}/wam7">
+      <sphere center="0 0 0" radius="0"/>
+    </link_sphere_approximation>
 
-        <!-- Sphere representation for CHOMP -->
-        <link_sphere_approximation link="/${prefix}/wam_base">
-            <sphere center="0.0 0.0 0.0" radius="0.15"/>
-        </link_sphere_approximation>
+  </xacro:macro>
 
-        <link_sphere_approximation link="/${prefix}/wam1">
-            <sphere center="0 0 0" radius="0"/>
-        </link_sphere_approximation>
+  <xacro:macro name="barretthand_endeffector" params="prefix:=${prefix}">
+    <!-- Must be included AFTER wam_manipulator -->
+    <group name="${prefix}_hand">
+      <link name="/${prefix}/hand_base"/>
+      <link name="/${prefix}/finger0_0"/>
+      <link name="/${prefix}/finger0_1"/>
+      <link name="/${prefix}/finger0_2"/>
+      <link name="/${prefix}/finger1_0"/>
+      <link name="/${prefix}/finger1_1"/>
+      <link name="/${prefix}/finger1_2"/>
+      <link name="/${prefix}/finger2_1"/>
+      <link name="/${prefix}/finger2_2"/>
+    </group>
 
-        <link_sphere_approximation link="/${prefix}/wam2">
-            <sphere center="0.0 -0.2 0.0" radius="0.06"/>
-            <sphere center="0.0 -0.3 0.0" radius="0.06"/>
-            <sphere center="0.0 -0.4 0.0" radius="0.06"/>
-            <sphere center="0.0 -0.5 0.0" radius="0.06"/>
-        </link_sphere_approximation>
+    <end_effector name="${prefix}_hand" group="${prefix}_hand"
+                  parent_link="/${prefix}/wam7" parent_group="${prefix}"/>
 
-        <link_sphere_approximation link="/${prefix}/wam3">
-            <sphere center=" 0.045 0.0 0.55" radius="0.06"/>
-        </link_sphere_approximation>
+    <!-- Disable collisions between the fingers. -->
+    <disable_collisions link1="/${prefix}/finger0_0" link2="/${prefix}/finger1_0"/>
+    <disable_collisions link1="/${prefix}/finger0_0" link2="/${prefix}/finger0_1"/>
+    <disable_collisions link1="/${prefix}/finger0_0" link2="/${prefix}/finger0_2"/>
+    <disable_collisions link1="/${prefix}/finger0_0" link2="/${prefix}/finger1_1"/>
+    <disable_collisions link1="/${prefix}/finger0_0" link2="/${prefix}/finger1_2"/>
+    <disable_collisions link1="/${prefix}/finger0_0" link2="/${prefix}/finger2_1"/>
+    <disable_collisions link1="/${prefix}/finger0_0" link2="/${prefix}/finger2_2"/>
 
-        <link_sphere_approximation link="/${prefix}/wam4">
-            <sphere center="-0.045 -0.2  0.0" radius="0.06"/>
-            <sphere center="-0.045 -0.1  0.0" radius="0.06"/>
-            <sphere center="-0.045 -0.3  0.0" radius="0.06"/>
-        </link_sphere_approximation>
+    <disable_collisions link1="/${prefix}/finger1_0" link2="/${prefix}/finger0_1"/>
+    <disable_collisions link1="/${prefix}/finger1_0" link2="/${prefix}/finger0_2"/>
+    <disable_collisions link1="/${prefix}/finger1_0" link2="/${prefix}/finger1_1"/>
+    <disable_collisions link1="/${prefix}/finger1_0" link2="/${prefix}/finger1_2"/>
+    <disable_collisions link1="/${prefix}/finger1_0" link2="/${prefix}/finger2_1"/>
+    <disable_collisions link1="/${prefix}/finger1_0" link2="/${prefix}/finger2_2"/>
 
-        <link_sphere_approximation link="/${prefix}/wam5">
-            <sphere center="0 0 0" radius="0"/>
-        </link_sphere_approximation>
+    <disable_collisions link1="/${prefix}/finger0_1" link2="/${prefix}/finger0_2"/>
+    <disable_collisions link1="/${prefix}/finger0_1" link2="/${prefix}/finger1_1"/>
+    <disable_collisions link1="/${prefix}/finger0_1" link2="/${prefix}/finger1_2"/>
+    <disable_collisions link1="/${prefix}/finger0_1" link2="/${prefix}/finger2_1"/>
+    <disable_collisions link1="/${prefix}/finger0_1" link2="/${prefix}/finger2_2"/>
 
-        <link_sphere_approximation link="/${prefix}/wam6">
-            <sphere center="0.0 -0.1 0.0" radius="0.06"/>
-        </link_sphere_approximation>
+    <disable_collisions link1="/${prefix}/finger0_2" link2="/${prefix}/finger1_1"/>
+    <disable_collisions link1="/${prefix}/finger0_2" link2="/${prefix}/finger1_2"/>
+    <disable_collisions link1="/${prefix}/finger0_2" link2="/${prefix}/finger2_1"/>
+    <disable_collisions link1="/${prefix}/finger0_2" link2="/${prefix}/finger2_2"/>
 
-        <!-- FIXME: Shouldn't wam7 have a sphere? -->
-        <link_sphere_approximation link="/${prefix}/wam7">
-            <sphere center="0 0 0" radius="0"/>
-        </link_sphere_approximation>
+    <disable_collisions link1="/${prefix}/finger1_1" link2="/${prefix}/finger1_2"/>
+    <disable_collisions link1="/${prefix}/finger1_1" link2="/${prefix}/finger2_1"/>
+    <disable_collisions link1="/${prefix}/finger1_1" link2="/${prefix}/finger2_2"/>
 
-        <link_sphere_approximation link="/${prefix}/finger0_1">
-            <sphere center="0.05 -0.01 0.0" radius="0.04"/>
-        </link_sphere_approximation>
+    <disable_collisions link1="/${prefix}/finger1_2" link2="/${prefix}/finger2_1"/>
+    <disable_collisions link1="/${prefix}/finger1_2" link2="/${prefix}/finger2_2"/>
+    <disable_collisions link1="/${prefix}/finger2_1" link2="/${prefix}/finger2_2"/>
 
-        <link_sphere_approximation link="/${prefix}/finger1_1">
-            <sphere center="0.05 -0.01 0.0" radius="0.04"/>
-        </link_sphere_approximation>
+    <!-- Disable collisions between the fingers and the palm. -->
+    <disable_collisions link1="/${prefix}/hand_base" link2="/${prefix}/finger1_0"/>
+    <disable_collisions link1="/${prefix}/hand_base" link2="/${prefix}/finger0_1"/>
+    <disable_collisions link1="/${prefix}/hand_base" link2="/${prefix}/finger0_2"/>
+    <disable_collisions link1="/${prefix}/hand_base" link2="/${prefix}/finger1_1"/>
+    <disable_collisions link1="/${prefix}/hand_base" link2="/${prefix}/finger1_2"/>
+    <disable_collisions link1="/${prefix}/hand_base" link2="/${prefix}/finger2_1"/>
+    <disable_collisions link1="/${prefix}/hand_base" link2="/${prefix}/finger2_2"/>
 
-        <link_sphere_approximation link="/${prefix}/finger2_1">
-            <sphere center="0.05 -0.01 0.0" radius="0.04"/>
-        </link_sphere_approximation>
+    <!-- Disable collisions between palm and WAM end link -->
+    <disable_collisions link1="/${prefix}/wam6" link2="/${prefix}/hand_base"/>
 
-        <link_sphere_approximation link="/${prefix}/finger0_2">
-            <sphere center="0.05 0.0 0.0" radius="0.04"/>
-        </link_sphere_approximation>
+    <!-- Sphere representation for CHOMP -->
+    <link_sphere_approximation link="/${prefix}/finger0_1">
+      <sphere center="0.05 -0.01 0.0" radius="0.04"/>
+    </link_sphere_approximation>
 
-        <link_sphere_approximation link="/${prefix}/finger1_2">
-            <sphere center="0.05 0.0 0.0" radius="0.04"/>
-        </link_sphere_approximation>
+    <link_sphere_approximation link="/${prefix}/finger1_1">
+      <sphere center="0.05 -0.01 0.0" radius="0.04"/>
+    </link_sphere_approximation>
 
-        <link_sphere_approximation link="/${prefix}/finger2_2">
-            <sphere center="0.05 0.0 0.0" radius="0.04"/>
-        </link_sphere_approximation>
-    </xacro:macro>
+    <link_sphere_approximation link="/${prefix}/finger2_1">
+      <sphere center="0.05 -0.01 0.0" radius="0.04"/>
+    </link_sphere_approximation>
 
-    <xacro:macro name="pantilt" params="name">
-        <group name="${name}">
-            <link name="/herb_base"/>
-            <link name="/${name}/wam1"/>
-            <link name="/${name}/wam2"/>
+    <link_sphere_approximation link="/${prefix}/finger0_2">
+      <sphere center="0.05 0.0 0.0" radius="0.04"/>
+    </link_sphere_approximation>
 
-            <link_sphere_approximation link="/${name}/wam1">
-                <sphere center="0 0 0" radius="0.20"/>
-            </link_sphere_approximation>
+    <link_sphere_approximation link="/${prefix}/finger1_2">
+      <sphere center="0.05 0.0 0.0" radius="0.04"/>
+    </link_sphere_approximation>
 
-            <link_sphere_approximation link="/${name}/wam2">
-                <sphere center="0 0 0" radius="0"/>
-            </link_sphere_approximation>
-        </group>
+    <link_sphere_approximation link="/${prefix}/finger2_2">
+      <sphere center="0.05 0.0 0.0" radius="0.04"/>
+    </link_sphere_approximation>
+  </xacro:macro>
 
-        <!-- Dummy group to make the head look like an end-effector; e.g. to
-             run inverse kinematics. HERB doesn't actually have a gripper on
-             his head (maybe on HERB3?). -->
-        <group name="${name}_hand"/>
+  <xacro:macro name="pantilt" params="name">
+    <group name="${name}">
+      <link name="/herb_base"/>
+      <link name="/${name}/wam1"/>
+      <link name="/${name}/wam2"/>
 
-        <end_effector name="head" group="${name}_hand"
-                      parent_link="/${name}/wam2" parent_group="${name}"/>
-    </xacro:macro>
+      <link_sphere_approximation link="/${name}/wam1">
+        <sphere center="0 0 0" radius="0.20"/>
+      </link_sphere_approximation>
 
-    <xacro:wam_bh280_manipulator prefix="left"/>
-    <xacro:wam_bh280_manipulator prefix="right"/>
-    <xacro:pantilt name="head"/>
+      <link_sphere_approximation link="/${name}/wam2">
+        <sphere center="0 0 0" radius="0"/>
+      </link_sphere_approximation>
+    </group>
 
-    <passive_joint name="/segway_wheel_left"/>
-    <passive_joint name="/segway_wheel_right"/>
+    <!-- Dummy group to make the head look like an end-effector; e.g. to
+         run inverse kinematics. HERB doesn't actually have a gripper on
+         his head (maybe on HERB3?). -->
+    <group name="${name}_hand"/>
 
-    <disable_collisions link1="/left/wam_base" link2="/right/wam_base"/>
-    <disable_collisions link1="/left/wam1" link2="/right/wam1"/>
-    <disable_collisions link1="/herb_base" link2="/head/wam2" />
+    <end_effector name="head" group="${name}_hand"
+                  parent_link="/${name}/wam2" parent_group="${name}"/>
+  </xacro:macro>
 
-    <!-- Automatically-generated by the MoveIt setup assistant. -->
-    <!--
-    <disable_collisions link1="/head/wam1" link2="/head/wam2" reason="Adjacent" />
-    <disable_collisions link1="/head/wam1" link2="/herb_base" reason="Adjacent" />
-    <disable_collisions link1="/head/wam1" link2="/left/wam1" reason="Never" />
-    <disable_collisions link1="/head/wam1" link2="/left/wam2" reason="Never" />
-    <disable_collisions link1="/head/wam1" link2="/left/wam_base" reason="Never" />
-    <disable_collisions link1="/head/wam1" link2="/right/wam1" reason="Never" />
-    <disable_collisions link1="/head/wam1" link2="/right/wam2" reason="Never" />
-    <disable_collisions link1="/head/wam1" link2="/right/wam_base" reason="Never" />
-    <disable_collisions link1="/head/wam1" link2="/segway_wheel_left" reason="Never" />
-    <disable_collisions link1="/head/wam1" link2="/segway_wheel_right" reason="Never" />
-    <disable_collisions link1="/head/wam2" link2="/herb_base" reason="Always" />
-    <disable_collisions link1="/head/wam2" link2="/left/wam1" reason="Never" />
-    <disable_collisions link1="/head/wam2" link2="/left/wam2" reason="Never" />
-    <disable_collisions link1="/head/wam2" link2="/left/wam_base" reason="Never" />
-    <disable_collisions link1="/head/wam2" link2="/right/wam1" reason="Never" />
-    <disable_collisions link1="/head/wam2" link2="/right/wam2" reason="Never" />
-    <disable_collisions link1="/head/wam2" link2="/right/wam_base" reason="Never" />
-    <disable_collisions link1="/head/wam2" link2="/segway_wheel_left" reason="Never" />
-    <disable_collisions link1="/head/wam2" link2="/segway_wheel_right" reason="Never" />
-    <disable_collisions link1="/herb_base" link2="/left/wam1" reason="Default" />
-    <disable_collisions link1="/herb_base" link2="/left/wam2" reason="Never" />
-    <disable_collisions link1="/herb_base" link2="/left/wam_base" reason="Adjacent" />
-    <disable_collisions link1="/herb_base" link2="/right/wam1" reason="Default" />
-    <disable_collisions link1="/herb_base" link2="/right/wam2" reason="Never" />
-    <disable_collisions link1="/herb_base" link2="/right/wam_base" reason="Adjacent" />
-    <disable_collisions link1="/herb_base" link2="/segway_wheel_left" reason="Adjacent" />
-    <disable_collisions link1="/herb_base" link2="/segway_wheel_right" reason="Adjacent" />
-    <disable_collisions link1="/left/finger0_0" link2="/left/finger0_1" reason="Adjacent" />
-    <disable_collisions link1="/left/finger0_0" link2="/left/finger0_2" reason="Never" />
-    <disable_collisions link1="/left/finger0_0" link2="/left/finger1_0" reason="Never" />
-    <disable_collisions link1="/left/finger0_0" link2="/left/finger1_1" reason="Never" />
-    <disable_collisions link1="/left/finger0_0" link2="/left/hand_base" reason="Adjacent" />
-    <disable_collisions link1="/left/finger0_0" link2="/left/wam4" reason="Never" />
-    <disable_collisions link1="/left/finger0_0" link2="/left/wam5" reason="Never" />
-    <disable_collisions link1="/left/finger0_0" link2="/left/wam6" reason="Never" />
-    <disable_collisions link1="/left/finger0_0" link2="/left/wam7" reason="Never" />
-    <disable_collisions link1="/left/finger0_1" link2="/left/finger0_2" reason="Adjacent" />
-    <disable_collisions link1="/left/finger0_1" link2="/left/finger1_0" reason="Never" />
-    <disable_collisions link1="/left/finger0_1" link2="/left/finger1_1" reason="Never" />
-    <disable_collisions link1="/left/finger0_1" link2="/left/hand_base" reason="Default" />
-    <disable_collisions link1="/left/finger0_1" link2="/left/wam4" reason="Never" />
-    <disable_collisions link1="/left/finger0_1" link2="/left/wam5" reason="Never" />
-    <disable_collisions link1="/left/finger0_1" link2="/left/wam6" reason="Never" />
-    <disable_collisions link1="/left/finger0_1" link2="/left/wam7" reason="Never" />
-    <disable_collisions link1="/left/finger0_2" link2="/left/wam4" reason="Never" />
-    <disable_collisions link1="/left/finger0_2" link2="/left/wam5" reason="Never" />
-    <disable_collisions link1="/left/finger0_2" link2="/left/wam6" reason="Never" />
-    <disable_collisions link1="/left/finger0_2" link2="/left/wam7" reason="Never" />
-    <disable_collisions link1="/left/finger1_0" link2="/left/finger1_1" reason="Adjacent" />
-    <disable_collisions link1="/left/finger1_0" link2="/left/finger1_2" reason="Never" />
-    <disable_collisions link1="/left/finger1_0" link2="/left/finger2_2" reason="Never" />
-    <disable_collisions link1="/left/finger1_0" link2="/left/hand_base" reason="Adjacent" />
-    <disable_collisions link1="/left/finger1_0" link2="/left/wam4" reason="Never" />
-    <disable_collisions link1="/left/finger1_0" link2="/left/wam5" reason="Never" />
-    <disable_collisions link1="/left/finger1_0" link2="/left/wam6" reason="Never" />
-    <disable_collisions link1="/left/finger1_0" link2="/left/wam7" reason="Never" />
-    <disable_collisions link1="/left/finger1_1" link2="/left/finger1_2" reason="Adjacent" />
-    <disable_collisions link1="/left/finger1_1" link2="/left/hand_base" reason="Default" />
-    <disable_collisions link1="/left/finger1_1" link2="/left/wam4" reason="Never" />
-    <disable_collisions link1="/left/finger1_1" link2="/left/wam5" reason="Never" />
-    <disable_collisions link1="/left/finger1_1" link2="/left/wam6" reason="Never" />
-    <disable_collisions link1="/left/finger1_1" link2="/left/wam7" reason="Never" />
-    <disable_collisions link1="/left/finger1_2" link2="/left/wam4" reason="Never" />
-    <disable_collisions link1="/left/finger1_2" link2="/left/wam5" reason="Never" />
-    <disable_collisions link1="/left/finger1_2" link2="/left/wam6" reason="Never" />
-    <disable_collisions link1="/left/finger1_2" link2="/left/wam7" reason="Never" />
-    <disable_collisions link1="/left/finger2_1" link2="/left/finger2_2" reason="Adjacent" />
-    <disable_collisions link1="/left/finger2_1" link2="/left/hand_base" reason="Adjacent" />
-    <disable_collisions link1="/left/finger2_1" link2="/left/wam4" reason="Never" />
-    <disable_collisions link1="/left/finger2_1" link2="/left/wam5" reason="Never" />
-    <disable_collisions link1="/left/finger2_1" link2="/left/wam6" reason="Never" />
-    <disable_collisions link1="/left/finger2_1" link2="/left/wam7" reason="Never" />
-    <disable_collisions link1="/left/finger2_2" link2="/left/wam4" reason="Never" />
-    <disable_collisions link1="/left/finger2_2" link2="/left/wam5" reason="Never" />
-    <disable_collisions link1="/left/finger2_2" link2="/left/wam6" reason="Never" />
-    <disable_collisions link1="/left/finger2_2" link2="/left/wam7" reason="Never" />
-    <disable_collisions link1="/left/hand_base" link2="/left/wam4" reason="Never" />
-    <disable_collisions link1="/left/hand_base" link2="/left/wam5" reason="Never" />
-    <disable_collisions link1="/left/hand_base" link2="/left/wam6" reason="Never" />
-    <disable_collisions link1="/left/hand_base" link2="/left/wam7" reason="Adjacent" />
-    <disable_collisions link1="/left/wam1" link2="/left/wam2" reason="Adjacent" />
-    <disable_collisions link1="/left/wam1" link2="/left/wam3" reason="Default" />
-    <disable_collisions link1="/left/wam1" link2="/left/wam4" reason="Never" />
-    <disable_collisions link1="/left/wam1" link2="/left/wam5" reason="Never" />
-    <disable_collisions link1="/left/wam1" link2="/left/wam_base" reason="Adjacent" />
-    <disable_collisions link1="/left/wam1" link2="/right/wam2" reason="Never" />
-    <disable_collisions link1="/left/wam1" link2="/right/wam_base" reason="Never" />
-    <disable_collisions link1="/left/wam1" link2="/segway_wheel_left" reason="Never" />
-    <disable_collisions link1="/left/wam1" link2="/segway_wheel_right" reason="Never" />
-    <disable_collisions link1="/left/wam2" link2="/left/wam3" reason="Adjacent" />
-    <disable_collisions link1="/left/wam2" link2="/left/wam4" reason="Never" />
-    <disable_collisions link1="/left/wam2" link2="/left/wam5" reason="Never" />
-    <disable_collisions link1="/left/wam2" link2="/left/wam6" reason="Never" />
-    <disable_collisions link1="/left/wam2" link2="/left/wam7" reason="Never" />
-    <disable_collisions link1="/left/wam2" link2="/left/wam_base" reason="Never" />
-    <disable_collisions link1="/left/wam2" link2="/right/wam1" reason="Never" />
-    <disable_collisions link1="/left/wam2" link2="/right/wam2" reason="Never" />
-    <disable_collisions link1="/left/wam2" link2="/right/wam_base" reason="Never" />
-    <disable_collisions link1="/left/wam2" link2="/segway_wheel_left" reason="Never" />
-    <disable_collisions link1="/left/wam2" link2="/segway_wheel_right" reason="Never" />
-    <disable_collisions link1="/left/wam3" link2="/left/wam4" reason="Adjacent" />
-    <disable_collisions link1="/left/wam3" link2="/left/wam_base" reason="Never" />
-    <disable_collisions link1="/left/wam4" link2="/left/wam5" reason="Adjacent" />
-    <disable_collisions link1="/left/wam4" link2="/left/wam6" reason="Default" />
-    <disable_collisions link1="/left/wam5" link2="/left/wam6" reason="Adjacent" />
-    <disable_collisions link1="/left/wam6" link2="/left/wam7" reason="Adjacent" />
-    <disable_collisions link1="/left/wam_base" link2="/right/wam1" reason="Never" />
-    <disable_collisions link1="/left/wam_base" link2="/right/wam2" reason="Never" />
-    <disable_collisions link1="/left/wam_base" link2="/right/wam_base" reason="Never" />
-    <disable_collisions link1="/left/wam_base" link2="/segway_wheel_left" reason="Never" />
-    <disable_collisions link1="/left/wam_base" link2="/segway_wheel_right" reason="Never" />
-    <disable_collisions link1="/right/finger0_0" link2="/right/finger0_1" reason="Adjacent" />
-    <disable_collisions link1="/right/finger0_0" link2="/right/finger0_2" reason="Never" />
-    <disable_collisions link1="/right/finger0_0" link2="/right/finger1_0" reason="Never" />
-    <disable_collisions link1="/right/finger0_0" link2="/right/finger1_1" reason="Never" />
-    <disable_collisions link1="/right/finger0_0" link2="/right/hand_base" reason="Adjacent" />
-    <disable_collisions link1="/right/finger0_0" link2="/right/wam4" reason="Never" />
-    <disable_collisions link1="/right/finger0_0" link2="/right/wam5" reason="Never" />
-    <disable_collisions link1="/right/finger0_0" link2="/right/wam6" reason="Never" />
-    <disable_collisions link1="/right/finger0_0" link2="/right/wam7" reason="Never" />
-    <disable_collisions link1="/right/finger0_1" link2="/right/finger0_2" reason="Adjacent" />
-    <disable_collisions link1="/right/finger0_1" link2="/right/finger1_0" reason="Never" />
-    <disable_collisions link1="/right/finger0_1" link2="/right/finger1_1" reason="Never" />
-    <disable_collisions link1="/right/finger0_1" link2="/right/hand_base" reason="Default" />
-    <disable_collisions link1="/right/finger0_1" link2="/right/wam4" reason="Never" />
-    <disable_collisions link1="/right/finger0_1" link2="/right/wam5" reason="Never" />
-    <disable_collisions link1="/right/finger0_1" link2="/right/wam6" reason="Never" />
-    <disable_collisions link1="/right/finger0_1" link2="/right/wam7" reason="Never" />
-    <disable_collisions link1="/right/finger0_2" link2="/right/wam4" reason="Never" />
-    <disable_collisions link1="/right/finger0_2" link2="/right/wam5" reason="Never" />
-    <disable_collisions link1="/right/finger0_2" link2="/right/wam6" reason="Never" />
-    <disable_collisions link1="/right/finger0_2" link2="/right/wam7" reason="Never" />
-    <disable_collisions link1="/right/finger1_0" link2="/right/finger1_1" reason="Adjacent" />
-    <disable_collisions link1="/right/finger1_0" link2="/right/finger1_2" reason="Never" />
-    <disable_collisions link1="/right/finger1_0" link2="/right/finger2_2" reason="Never" />
-    <disable_collisions link1="/right/finger1_0" link2="/right/hand_base" reason="Adjacent" />
-    <disable_collisions link1="/right/finger1_0" link2="/right/wam4" reason="Never" />
-    <disable_collisions link1="/right/finger1_0" link2="/right/wam5" reason="Never" />
-    <disable_collisions link1="/right/finger1_0" link2="/right/wam6" reason="Never" />
-    <disable_collisions link1="/right/finger1_0" link2="/right/wam7" reason="Never" />
-    <disable_collisions link1="/right/finger1_1" link2="/right/finger1_2" reason="Adjacent" />
-    <disable_collisions link1="/right/finger1_1" link2="/right/hand_base" reason="Default" />
-    <disable_collisions link1="/right/finger1_1" link2="/right/wam4" reason="Never" />
-    <disable_collisions link1="/right/finger1_1" link2="/right/wam5" reason="Never" />
-    <disable_collisions link1="/right/finger1_1" link2="/right/wam6" reason="Never" />
-    <disable_collisions link1="/right/finger1_1" link2="/right/wam7" reason="Never" />
-    <disable_collisions link1="/right/finger1_2" link2="/right/wam4" reason="Never" />
-    <disable_collisions link1="/right/finger1_2" link2="/right/wam5" reason="Never" />
-    <disable_collisions link1="/right/finger1_2" link2="/right/wam6" reason="Never" />
-    <disable_collisions link1="/right/finger1_2" link2="/right/wam7" reason="Never" />
-    <disable_collisions link1="/right/finger2_1" link2="/right/finger2_2" reason="Adjacent" />
-    <disable_collisions link1="/right/finger2_1" link2="/right/hand_base" reason="Adjacent" />
-    <disable_collisions link1="/right/finger2_1" link2="/right/wam4" reason="Never" />
-    <disable_collisions link1="/right/finger2_1" link2="/right/wam5" reason="Never" />
-    <disable_collisions link1="/right/finger2_1" link2="/right/wam6" reason="Never" />
-    <disable_collisions link1="/right/finger2_1" link2="/right/wam7" reason="Never" />
-    <disable_collisions link1="/right/finger2_2" link2="/right/wam4" reason="Never" />
-    <disable_collisions link1="/right/finger2_2" link2="/right/wam5" reason="Never" />
-    <disable_collisions link1="/right/finger2_2" link2="/right/wam6" reason="Never" />
-    <disable_collisions link1="/right/finger2_2" link2="/right/wam7" reason="Never" />
-    <disable_collisions link1="/right/hand_base" link2="/right/wam4" reason="Never" />
-    <disable_collisions link1="/right/hand_base" link2="/right/wam5" reason="Never" />
-    <disable_collisions link1="/right/hand_base" link2="/right/wam6" reason="Never" />
-    <disable_collisions link1="/right/hand_base" link2="/right/wam7" reason="Adjacent" />
-    <disable_collisions link1="/right/wam1" link2="/right/wam2" reason="Adjacent" />
-    <disable_collisions link1="/right/wam1" link2="/right/wam3" reason="Default" />
-    <disable_collisions link1="/right/wam1" link2="/right/wam4" reason="Never" />
-    <disable_collisions link1="/right/wam1" link2="/right/wam5" reason="Never" />
-    <disable_collisions link1="/right/wam1" link2="/right/wam_base" reason="Adjacent" />
-    <disable_collisions link1="/right/wam1" link2="/segway_wheel_left" reason="Never" />
-    <disable_collisions link1="/right/wam1" link2="/segway_wheel_right" reason="Never" />
-    <disable_collisions link1="/right/wam2" link2="/right/wam3" reason="Adjacent" />
-    <disable_collisions link1="/right/wam2" link2="/right/wam4" reason="Never" />
-    <disable_collisions link1="/right/wam2" link2="/right/wam5" reason="Never" />
-    <disable_collisions link1="/right/wam2" link2="/right/wam6" reason="Never" />
-    <disable_collisions link1="/right/wam2" link2="/right/wam7" reason="Never" />
-    <disable_collisions link1="/right/wam2" link2="/right/wam_base" reason="Never" />
-    <disable_collisions link1="/right/wam2" link2="/segway_wheel_left" reason="Never" />
-    <disable_collisions link1="/right/wam2" link2="/segway_wheel_right" reason="Never" />
-    <disable_collisions link1="/right/wam3" link2="/right/wam4" reason="Adjacent" />
-    <disable_collisions link1="/right/wam3" link2="/right/wam_base" reason="Never" />
-    <disable_collisions link1="/right/wam4" link2="/right/wam5" reason="Adjacent" />
-    <disable_collisions link1="/right/wam4" link2="/right/wam6" reason="Default" />
-    <disable_collisions link1="/right/wam5" link2="/right/wam6" reason="Adjacent" />
-    <disable_collisions link1="/right/wam6" link2="/right/wam7" reason="Adjacent" />
-    <disable_collisions link1="/right/wam_base" link2="/segway_wheel_left" reason="Never" />
-    <disable_collisions link1="/right/wam_base" link2="/segway_wheel_right" reason="Never" />
-    <disable_collisions link1="/segway_wheel_left" link2="/segway_wheel_right" reason="Never" />
-    -->
+  <xacro:arg name="left_hand" default="true"/>
+  <xacro:arg name="right_hand" default="true"/>
+
+  <xacro:wam_manipulator prefix="left"/>
+  <xacro:wam_manipulator prefix="right"/>
+
+  <xacro:if value="$(arg left_hand)">
+    <xacro:barrett_endeffector prefix="left"/>
+  </xacro:if>
+  <xacro:if value="$(arg right_hand)">
+    <xacro:barrett_endeffector prefix="right"/>
+  </xacro:if>
+
+  <xacro:pantilt name="head"/>
+
+  <passive_joint name="/segway_wheel_left"/>
+  <passive_joint name="/segway_wheel_right"/>
+
+  <disable_collisions link1="/left/wam_base" link2="/right/wam_base"/>
+  <disable_collisions link1="/left/wam1" link2="/right/wam1"/>
+  <disable_collisions link1="/herb_base" link2="/head/wam2" />
 </robot>

--- a/robots/herb.urdf.xacro
+++ b/robots/herb.urdf.xacro
@@ -44,6 +44,7 @@
     </xacro:if>
   </xacro:macro>
 
+  <!-- hand arguments should all default to false to make argument passing sane -->
   <xacro:arg name="left_bh280" default="false"/>
   <xacro:arg name="right_bh280" default="false"/>
 

--- a/robots/herb.urdf.xacro
+++ b/robots/herb.urdf.xacro
@@ -1,61 +1,67 @@
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="herb">
-    <xacro:property name="pi" value="3.14159265359"/>
 
-    <xacro:include filename="herb_base.urdf.xacro"/>
-    <xacro:include filename="bh280.urdf.xacro"/>
-    <xacro:include filename="wam.urdf.xacro"/>
-    <xacro:include filename="fixed_transforms.urdf.xacro"/>
+  <xacro:property name="pi" value="3.14159265359"/>
 
-    <!-- 7 DOF Barrett WAM equipped with the Barrett force/torque sensor and
-         the BH-280 BarrettHand end-effector. -->
-    <xacro:macro name="wam_ft_bh280" params="prefix">
-        <xacro:wam prefix="${prefix}"/>
-        <xacro:bh280 prefix="${prefix}"/>
+  <xacro:include filename="herb_base.urdf.xacro"/>
+  <xacro:include filename="bh280.urdf.xacro"/>
+  <xacro:include filename="wam.urdf.xacro"/>
+  <xacro:include filename="fixed_transforms.urdf.xacro"/>
 
-        <link name="${prefix}/force_torque">
-            <inertial>
-                <origin xyz="0.0002 0 0.0054" rpy="0 0 0"/>
-                <mass value="0.133278"/>
-                <inertia ixx="0.00007551" ixy="-0.0000001199" ixz="-0.0000000700"
-                                          iyy= "0.0000750800" iyz="-0.0000000537"
-                                                              izz= "0.0001462000"/>
-            </inertial>
-        </link>
-        <joint name="${prefix}/force_torque_mount" type="fixed">
-            <!-- difference between URDF wam7 frame and Barrett's wam7 frame is 0.06m -->
-            <origin xyz="0 0 0.06" rpy="0 0 0"/>
-            <parent link="${prefix}/wam7"/>
-            <child link="${prefix}/force_torque"/>
-        </joint>
+  <!-- 7 DOF Barrett WAM equipped with the Barrett force/torque sensor and
+       optionally the BH-280 BarrettHand end-effector. -->
+  <xacro:macro name="herb_manipulator"
+               params="prefix:=${prefix} bh280:=false">
+    <xacro:wam prefix="${prefix}"/>
 
-        <joint name="${prefix}/hand_mount" type="fixed">
-            <!-- The force/torque sensor is 12 mm thick. -->
-            <origin xyz="0 0 0.012" rpy="0 0 ${pi/2}"/>
-            <parent link="${prefix}/force_torque"/>
-            <child link="${prefix}/hand_base"/>
-        </joint>
-    </xacro:macro>
+    <xacro:if value="${bh280}">
+      <xacro:bh280 prefix="${prefix}"/>
+    </xacro:if>
 
-    <xacro:macro name="herb">
-        <xacro:wam_ft_bh280 prefix="/left"/>
-        <xacro:wam_ft_bh280 prefix="/right"/>
-        <xacro:herb_base prefix=""/>
+    <link name="${prefix}/force_torque">
+      <inertial>
+        <origin xyz="0.0002 0 0.0054" rpy="0 0 0"/>
+        <mass value="0.133278"/>
+        <inertia ixx="0.00007551" ixy="-0.0000001199" ixz="-0.0000000700"
+                 iyy= "0.0000750800" iyz="-0.0000000537"
+                 izz= "0.0001462000"/>
+      </inertial>
+    </link>
+    <joint name="${prefix}/force_torque_mount" type="fixed">
+      <!-- difference between URDF wam7 frame and Barrett's wam7 frame is 0.06m -->
+      <origin xyz="0 0 0.06" rpy="0 0 0"/>
+      <parent link="${prefix}/wam7"/>
+      <child link="${prefix}/force_torque"/>
+    </joint>
 
-        <joint name="/left/wam_mount" type="fixed">
-            <origin xyz="-0.266700 0.332276 0.694588" rpy="0 ${-pi/2} ${pi}"/>
-            <parent link="/herb_base"/>
-            <child link="/left/wam_base"/>
-        </joint>
+    <!-- TODO: where should force/torque thickness go if no hand? -->
+    <xacro:if value="${bh280}">
+      <joint name="${prefix}/hand_mount" type="fixed">
+        <!-- The force/torque sensor is 12 mm thick. -->
+        <origin xyz="0 0 0.012" rpy="0 0 ${pi/2}"/>
+        <parent link="${prefix}/force_torque"/>
+        <child link="${prefix}/hand_base"/>
+      </joint>
+    </xacro:if>
+  </xacro:macro>
 
-        <joint name="/right/wam_mount" type="fixed">
-            <origin xyz="-0.266700 -0.049121 0.694588" rpy="0 ${-pi/2} ${pi}"/>
+  <xacro:arg name="left_bh280" default="false"/>
+  <xacro:arg name="right_bh280" default="false"/>
 
-            <parent link="/herb_base"/>
-            <child link="/right/wam_base"/>
-        </joint>
-        
-        <xacro:fixed_transforms/>
-    </xacro:macro>
-    
-    <xacro:herb/>
+  <xacro:herb_manipulator prefix="/left" bh280="$(arg left_bh280)"/>
+  <xacro:herb_manipulator prefix="/right" bh280="$(arg right_bh280)"/>
+  <xacro:herb_base prefix=""/>
+
+  <joint name="/left/wam_mount" type="fixed">
+    <origin xyz="-0.266700 0.332276 0.694588" rpy="0 ${-pi/2} ${pi}"/>
+    <parent link="/herb_base"/>
+    <child link="/left/wam_base"/>
+  </joint>
+
+  <joint name="/right/wam_mount" type="fixed">
+    <origin xyz="-0.266700 -0.049121 0.694588" rpy="0 ${-pi/2} ${pi}"/>
+    <parent link="/herb_base"/>
+    <child link="/right/wam_base"/>
+  </joint>
+
+  <xacro:fixed_transforms/>
 </robot>

--- a/robots/herb_base.urdf.xacro
+++ b/robots/herb_base.urdf.xacro
@@ -1,0 +1,146 @@
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="herb_base">
+  <xacro:macro name="herb_base" params="prefix">
+    <link name="${prefix}/herb_base">
+      <inertial>
+        <origin xyz="-0.0809027982480422 0.00803042872866252 0.350693951417865" rpy="0 0 0"/>
+        <mass value="118.064183849969"/>
+        <inertia
+            ixx="9.67307679892718" ixy="-0.109440074935232" ixz="-2.47806317387667"
+            iyx="0.00000000000000" iyy="10.2602519302075"   iyz="0.237417248956334"
+            izx="0.00000000000000" izy="0.00000000000000"   izz="5.27441929623381"/>
+      </inertial>
+      <visual>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <mesh filename="package://herb_description/meshes/herb_base.dae"/>
+        </geometry>
+        <material name="">
+          <color rgba="0.086 0.408 0.565 1"/>
+        </material>
+      </visual>
+      <collision>
+        <geometry>
+          <mesh filename="package://herb_description/meshes/herb_base_collision.STL"/>
+        </geometry>
+      </collision>
+    </link>
+    <link name="${prefix}/segway_wheel_left">
+      <inertial>
+        <origin xyz="1.46252801536129E-12 4.14215883814961E-12 0.0471293756901144" rpy="0 0 0"/>
+        <mass value="6.7355511743555"/>
+        <inertia
+            ixx="0.092576479522193" ixy="-2.98851956896402E-06" ixz="1.06719826192435E-09"
+            iyx="0.000000000000000" iyy="0.0925839088729686"    iyz="3.02916843456587E-09"
+            izx="0.000000000000000" izy="0.0000000000000000"    izz="0.178365793214305"/>
+      </inertial>
+      <visual>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <mesh filename="package://herb_description/meshes/segway_wheel_left.dae"/>
+        </geometry>
+        <material name="">
+          <color rgba="0.2 0.2 0.2 1"/>
+        </material>
+      </visual>
+      <collision>
+        <geometry>
+          <mesh filename="package://herb_description/meshes/segway_wheel_left_collision.STL"/>
+        </geometry>
+      </collision>
+    </link>
+    <joint name="${prefix}/segway_wheel_left" type="continuous">
+      <origin xyz="0 0.231771918932663 0.23158735611353" rpy="-1.5707963267949 -0.115508699092541 0"/>
+      <parent link="${prefix}/herb_base"/>
+      <child link="${prefix}/segway_wheel_left"/>
+      <axis xyz="0 0 -1"/>
+    </joint>
+    <link name="${prefix}/segway_wheel_right">
+      <inertial>
+        <origin xyz="-1.06512021424976E-15 4.39884240144295E-12 0.0471293756901144" rpy="0 0 0"/>
+        <mass value="6.7355511743555"/>
+        <inertia
+            ixx="0.0925754265920571" ixy="-1.49287030220407E-10" ixz="-1.57504574648507E-16"
+            iyx="0.0000000000000000" iyy="0.0925849618031043"    iyz="3.21166212934922E-09"
+            izx="0.0000000000000000" izy="0.0000000000000000"    izz="0.178365793214305"/>
+      </inertial>
+      <visual>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <mesh filename="package://herb_description/meshes/segway_wheel_right.dae"/>
+        </geometry>
+        <material name="">
+          <color rgba="0.2 0.2 0.2 1"/>
+        </material>
+      </visual>
+      <collision>
+        <geometry>
+          <mesh filename="package://herb_description/meshes/segway_wheel_right_collision.STL"/>
+        </geometry>
+      </collision>
+    </link>
+    <joint name="${prefix}/segway_wheel_right" type="continuous">
+      <origin xyz="0 -0.231771918932663 0.231587356113537" rpy="-1.5707963267949 0.0751085369855802 3.14159265358979"/>
+      <parent link="${prefix}/herb_base"/>
+      <child link="${prefix}/segway_wheel_right"/>
+      <axis xyz="0 0 1"/>
+    </joint>
+    <link name="${prefix}/head/wam1">
+      <inertial>
+        <origin xyz="-0.000143379867888344 -0.0221150249825213 -0.0159634421249915" rpy="0 0 0"/>
+        <mass value="0.699914058257394"/>
+        <inertia
+            ixx="0.00280646384099311" ixy="6.06589910190362E-06" ixz="1.10356402708704E-06"
+            iyx="0.00000000000000000" iyy="0.000592185892279803" iyz="-0.000170166312219621"
+            izx="0.00000000000000000" izy="0.000000000000000000" izz="0.00264000882290309"/>
+      </inertial>
+      <visual>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <mesh filename="package://herb_description/meshes/head_wam1.dae"/>
+        </geometry>
+        <material name="">
+          <color rgba="0.086 0.408 0.565 1"/>
+        </material>
+      </visual>
+      <collision>
+        <geometry>
+        <mesh filename="package://herb_description/meshes/head_wam1_collision.STL"/></geometry>
+      </collision>
+    </link>
+    <joint name="${prefix}/head/wam1" type="fixed">
+      <origin xyz="-0.219043 0 1.282513" rpy="0 0 0"/>
+      <parent link="${prefix}/herb_base"/>
+      <child link="${prefix}/head/wam1"/>
+      <axis xyz="0 0 1"/>
+    </joint>
+    <link name="${prefix}/head/wam2">
+      <inertial>
+        <origin xyz="0.00676836020340077 0.0512494218238631 0.00803256112914554" rpy="0 0 0"/>
+        <mass value="1.54049400601599"/>
+        <inertia
+            ixx="0.0067835645951359" ixy="-0.000318213388742608" ixz="-0.000190037318422281"
+            iyx="0.0000000000000000" iyy="0.00662131693308525"   iyz="-0.000833945040621095"
+            izx="0.0000000000000000" izy="0.00000000000000000"   izz="0.00344340957107467"/>
+      </inertial>
+      <visual>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <mesh filename="package://herb_description/meshes/head_wam2.dae"/>
+        </geometry>
+        <material name="">
+          <color rgba="0.63921568627451 0.63921568627451 0.686274509803922 1"/>
+        </material>
+      </visual>
+      <collision>
+        <geometry>
+        <mesh filename="package://herb_description/meshes/head_wam2_collision.STL"/></geometry>
+      </collision>
+    </link>
+    <joint name="${prefix}/head/wam2" type="fixed">
+      <origin xyz="0 0 0" rpy="1.5707963267949 0.3 4.20797196041016E-14"/>
+      <parent link="${prefix}/head/wam1"/>
+      <child link="${prefix}/head/wam2"/>
+      <axis xyz="0 0 1"/>
+    </joint>
+  </xacro:macro>
+</robot>

--- a/robots/wam.urdf.xacro
+++ b/robots/wam.urdf.xacro
@@ -1,0 +1,245 @@
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="wam">
+  <xacro:macro name="wam" params="prefix">
+    <link name="${prefix}/wam_base">
+      <visual>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <mesh filename="package://herb_description/meshes/wam_base.dae"/>
+        </geometry>
+        <material name="">
+          <color rgba="0.792156862745098 0.819607843137255 0.933333333333333 1"/>
+        </material>
+      </visual>
+      <inertial>
+        <origin rpy="0 0 0" xyz="0.21556578 0.26189039 0.34533511"/>
+        <mass value="9.97059584"/>
+        <inertia
+            ixx="0.10916849" ixy="0.00640270" ixz="0.02557874"
+            iyx="0.00000000" iyy="0.18294303" iyz="0.00161433"
+            izx="0.00000000" izy="0.00000000" izz="0.11760385"/>
+      </inertial>
+      <collision>
+        <geometry><mesh filename="package://herb_description/meshes/wam_base_collision.STL"/>
+        </geometry>
+      </collision>
+    </link>
+    <link name="${prefix}/wam1">
+      <visual>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <mesh filename="package://herb_description/meshes/wam1.dae"/>
+        </geometry>
+        <material name="">
+          <color rgba="0.792156862745098 0.819607843137255 0.933333333333333 1"/>
+        </material>
+      </visual>
+      <inertial>
+        <origin rpy="-1.570796 0 0" xyz="-0.004434 -0.000665 -0.121890"/>
+        <mass value="10.76768767"/>
+        <inertia
+            ixx="0.13488033" ixy="-0.00213041" ixz="-0.00012485"
+            iyx="0.00000000" iyy="0.11328369" iyz="0.00068555"
+            izx="0.00000000" izy="0.00000000" izz="0.09046330"/>
+      </inertial>
+      <collision>
+        <geometry>
+          <mesh filename="package://herb_description/meshes/wam1_collision.STL"/>
+        </geometry>
+      </collision>
+    </link>
+    <joint name="${prefix}/j1" type="revolute">
+      <origin xyz="0.22 0.14 0.346" rpy="-1.1127E-16 0 0"/>
+      <parent link="${prefix}/wam_base"/>
+      <child link="${prefix}/wam1"/>
+      <axis xyz="0 0 1"/>
+      <!-- HERB's J1 joints are modified to have a +180 degree offset. -->
+      <limit effort="1.8" lower="0.54159265359" upper="5.74159265359" velocity="0.75"/>
+    </joint>
+    <link name="${prefix}/wam2">
+      <visual>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <mesh filename="package://herb_description/meshes/wam2.dae"/>
+        </geometry>
+        <material name="">
+          <color rgba="0.792156862745098 0.819607843137255 0.933333333333333 1"/>
+        </material>
+      </visual>
+      <inertial>
+        <origin rpy="1.570796 0 0" xyz="-0.002370 -0.015421 0.031056"/>
+        <mass value="3.87493756"/>
+        <inertia
+            ixx="0.02140958" ixy="0.00027172" ixz="0.00002461"
+            iyx="0.00000000" iyy="0.01377875" iyz="-0.00181920"
+            izx="0.00000000" izy="0.00000000" izz="0.01558906"/>
+      </inertial>
+      <collision>
+        <geometry>
+          <mesh filename="package://herb_description/meshes/wam2_collision.STL"/>
+        </geometry>
+      </collision>
+    </link>
+    <joint name="${prefix}/j2" type="revolute">
+      <origin xyz="0 0 0" rpy="-1.5708 -4.0281E-16 -3.9443E-31"/>
+      <parent link="${prefix}/wam1"/>
+      <child link="${prefix}/wam2"/>
+      <axis xyz="0 0 1"/>
+      <limit effort="1.8" lower="-2.00" upper="2.00" velocity="0.75"/>
+    </joint>
+    <link name="${prefix}/wam3">
+      <visual>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <mesh filename="package://herb_description/meshes/wam3.dae"/>
+        </geometry>
+        <material name="">
+          <color rgba="0.792156862745098 0.819607843137255 0.933333333333333 1"/>
+        </material>
+      </visual>
+      <inertial>
+        <origin rpy="-1.570796 0 0" xyz="0.006741 0.000033 0.342492"/>
+        <mass value="1.80228141"/>
+        <inertia
+            ixx="0.05911077" ixy="-0.00249612" ixz="0.00000738"
+            iyx="0.00000000" iyy="0.00324550"  iyz="-0.00001767"
+            izx="0.00000000" izy="0.00000000"  izz="0.05927043"/>
+      </inertial>
+      <collision>
+        <geometry>
+          <mesh filename="package://herb_description/meshes/wam3_collision.STL"/>
+        </geometry>
+      </collision>
+    </link>
+    <joint name="${prefix}/j3" type="revolute">
+      <origin xyz="0 0 0" rpy="1.5708 -3.9443E-31 4.0281E-16"/>
+      <parent link="${prefix}/wam2"/>
+      <child link="${prefix}/wam3"/>
+      <axis xyz="0 0 1"/>
+      <limit effort="1.8" lower="-2.80" upper="2.80" velocity="2.0"/>
+    </joint>
+    <link name="${prefix}/wam4">
+      <visual>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <mesh filename="package://herb_description/meshes/wam4.dae"/>
+        </geometry>
+        <material name="">
+          <color rgba="0.792156862745098 0.819607843137255 0.933333333333333 1"/>
+        </material>
+      </visual>
+      <inertial>
+        <origin rpy="1.570796 0 0" xyz="-0.040015 -0.132717 -0.000229"/>
+        <mass value="2.40016804"/>
+        <inertia
+            ixx="0.01491672" ixy="0.00001741" ixz="-0.00150604"
+            iyx="0.00000000" iyy="0.01482922" iyz="-0.00002109"
+            izx="0.00000000" izy="0.00000000" izz="0.00294463"/>
+      </inertial>
+      <collision>
+        <geometry>
+          <mesh filename="package://herb_description/meshes/wam4_collision.STL"/>
+        </geometry>
+      </collision>
+    </link>
+    <joint name="${prefix}/j4" type="revolute">
+      <origin xyz="0.045 0 0.55" rpy="-1.5708 0 0"/>
+      <parent link="${prefix}/wam3"/>
+      <child link="${prefix}/wam4"/>
+      <axis xyz="0 0 1"/>
+      <limit effort="1.6" lower="-0.90" upper="3.10" velocity="2.0"/>
+    </joint>
+    <link name="${prefix}/wam5">
+      <visual>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <mesh filename="package://herb_description/meshes/wam5.dae"/>
+        </geometry>
+        <material name="">
+          <color rgba="0.792156862745098 0.819607843137255 0.933333333333333 1"/>
+        </material>
+      </visual>
+      <inertial>
+        <origin rpy="-1.570796 0 0" xyz="0.000089 0.004358 0.294888"/>
+        <mass value="0.12376019"/>
+        <inertia
+            ixx="0.00005029" ixy="0.00000020" ixz="-0.00000005"
+            iyx="0.00000000" iyy="0.00007582" iyz="-0.00000359"
+            izx="0.00000000" izy="0.00000000" izz="0.00006270"/>
+      </inertial>
+      <collision>
+        <geometry>
+          <mesh filename="package://herb_description/meshes/wam5_collision.STL"/>
+        </geometry>
+      </collision>
+    </link>
+    <joint name="${prefix}/j5" type="revolute">
+      <origin xyz="-0.045 0 0" rpy="1.5708 0 0"/>
+      <parent link="${prefix}/wam4"/>
+      <child link="${prefix}/wam5"/>
+      <axis xyz="0 0 1"/>
+      <limit effort="0.6" lower="-4.76" upper="1.24" velocity="2.5"/>
+    </joint>
+    <link name="${prefix}/wam6">
+      <visual>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <mesh filename="package://herb_description/meshes/wam6.dae"/>
+        </geometry>
+        <material name="">
+          <color rgba="0.792156862745098 0.819607843137255 0.933333333333333 1"/>
+        </material>
+      </visual>
+      <inertial>
+        <origin rpy="1.570796 0 0" xyz="-0.000123 -0.024683 -0.017032"/>
+        <mass value="0.41797364"/>
+        <inertia
+            ixx="0.00055516" ixy="0.00000061" ixz="-0.00000074"
+            iyx="0.00000000" iyy="0.00024367" iyz="-0.00004590"
+            izx="0.00000000" izy="0.00000000" izz="0.00045358"/>
+      </inertial>
+      <collision>
+        <geometry>
+          <mesh filename="package://herb_description/meshes/wam6_collision.STL"/>
+        </geometry>
+      </collision>
+    </link>
+    <joint name="${prefix}/j6" type="revolute">
+      <origin xyz="0 0 0.3" rpy="-1.5708 0 0"/>
+      <parent link="${prefix}/wam5"/>
+      <child link="${prefix}/wam6"/>
+      <axis xyz="0 0 1"/>
+      <limit effort="0.6" lower="-1.60" upper="1.60" velocity="2.5"/>
+    </joint>
+    <link name="${prefix}/wam7">
+      <visual>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <mesh filename="package://herb_description/meshes/wam7.dae"/>
+        </geometry>
+        <material name="">
+          <color rgba="0.792156862745098 0.819607843137255 0.933333333333333 1"/>
+        </material>
+      </visual>
+      <inertial>
+        <origin rpy="0 0 0" xyz="-0.000080 0.000163 0.056764"/>
+        <mass value="0.06864753"/>
+        <inertia
+            ixx="0.00003773" ixy="-0.00000019" ixz="0.00000000"
+            iyx="0.00000000" iyy="0.00003806"  iyz="0.00000000"
+            izx="0.00000000" izy="0.00000000"  izz="0.00007408"/>
+      </inertial>
+      <collision>
+        <geometry>
+          <mesh filename="package://herb_description/meshes/wam7_collision.STL"/>
+        </geometry>
+      </collision>
+    </link>
+    <joint name="${prefix}/j7" type="revolute">
+      <origin xyz="0 0 0" rpy="1.5708 0 0"/>
+      <parent link="${prefix}/wam6"/>
+      <child link="${prefix}/wam7"/>
+      <axis xyz="0 0 1"/>
+      <limit effort="0.174" lower="-3.00" upper="3.00" velocity="2.5"/>
+    </joint>
+  </xacro:macro>
+</robot>


### PR DESCRIPTION
I completely refactored the xacro build, removing the python processing and just committing the "intermediate" files we always use. The build is much cleaner now and should have no problems with not detecting source file changes. The diff is a little crazy because of the deletions, so I recommend looking at the actual files.

Additionally, we can now optionally build a matrix of HERB models (including SRDFs) with different hand combinations:

| LEFT | RIGHT |
| --- | --- |
| BH280 | BH280 |
| BH280 | None |
| None | BH280 |
| None | None |

The "standard" herb model output name is unchanged and so backwards compatible. We still need to add flags to the state-publisher to load the model we want to use, and then refactor herbpy to read from `/robot_description` and `/semantic_robot_description` when not in simulation.
