### PR TITLE
Change base link name

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ herb_description contains URDF and SRDF descriptions of HERB, a bimanual mobile
 manipulation robot designed and built by the
 [Personal Robotics Lab](https://personalrobotics.ri.cmu.edu) in the
 [Robotics Institute](https://www.ri.cmu.edu) at
-[Carnegie Mellon University](http://www.cmu.edu).
+[Carnegie Mellon University](http://www.cmu.edu). We follow [REP 120](http://www.ros.org/reps/rep-0120.html).
 
 
 ## SolidWorks Export

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ herb_description contains URDF and SRDF descriptions of HERB, a bimanual mobile
 manipulation robot designed and built by the
 [Personal Robotics Lab](https://personalrobotics.ri.cmu.edu) in the
 [Robotics Institute](https://www.ri.cmu.edu) at
-[Carnegie Mellon University](http://www.cmu.edu). We follow [REP 120](http://www.ros.org/reps/rep-0120.html).
+[Carnegie Mellon University](http://www.cmu.edu). The URDF descriptions follow [REP 120](http://www.ros.org/reps/rep-0120.html).
 
 
 ## SolidWorks Export

--- a/robots/herb_base.urdf.xacro
+++ b/robots/herb_base.urdf.xacro
@@ -1,6 +1,6 @@
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="herb_base">
   <xacro:macro name="herb_base" params="prefix">
-    <link name="herb_base_link">
+    <link name="base_footprint">
       <inertial>
         <origin
             xyz="0 0 0"
@@ -64,7 +64,7 @@
           xyz="0 0 1.05"
           rpy="0 0 -1.57075" />
       <parent
-          link="herb_base_link" />
+          link="base_footprint" />
       <child
           link="herb_frame" />
     </joint>


### PR DESCRIPTION
Changes base link's name to `base_footprint` to follow REP-120.