### PR TITLE
Use non-zero mass on fake links

### DIFF
--- a/robots/fixed_transforms.urdf.xacro
+++ b/robots/fixed_transforms.urdf.xacro
@@ -3,7 +3,7 @@
 
     <xacro:macro name="no_inertia">
       <inertial>
-        <mass value="0"/>
+        <mass value="0.001"/>
         <inertia ixx="0" ixy="0" ixz="0" iyy="0" iyz="0" izz="0"/>
       </inertial>
     </xacro:macro>


### PR DESCRIPTION
`rewd_controllers` requires that all links have non-zero mass. Links with zero mass can cause inverse dynamics to fail, e.g. return `INF` or `NaN` values, which is potentially dangerous in a controller.