### PR TITLE
Fix the Self-Collision in the Model

### DIFF
--- a/robots/herb_base.urdf.xacro
+++ b/robots/herb_base.urdf.xacro
@@ -367,7 +367,7 @@
           link="head/kinect2_link" />
       <origin
           xyz="-0.003895 -0.170163 0.017938"
-          rpy="3.14159 0 0" />
+          rpy="3.14159 1.57075 0" />
     </joint>
   </xacro:macro>
 </robot>

--- a/robots/herb_base.urdf.xacro
+++ b/robots/herb_base.urdf.xacro
@@ -367,7 +367,7 @@
           link="head/kinect2_link" />
       <origin
           xyz="-0.003895 -0.170163 0.017938"
-          rpy="3.14159 1.57075 0" />
+          rpy="0 1.57075 0" />
     </joint>
   </xacro:macro>
 </robot>


### PR DESCRIPTION
This PR corrects the orientation of the kinect sensor in the model. 
1. The changes have been tested in *simulation* by running `pantry-loading`. 
2. The tests that have been failing as reported in  https://github.com/personalrobotics/libherb/issues/38 now successfully pass.

This change needs to be verified, still, on real hardware with actual perception.