### PR TITLE
made the head brighter for better visualization.. 

### DIFF
--- a/robots/herb_base.urdf.xacro
+++ b/robots/herb_base.urdf.xacro
@@ -267,7 +267,7 @@
         <material
             name="">
           <color
-              rgba="0 0 0 1" />
+              rgba="0.3 0.3 0.3 1" />
         </material>
       </visual>
       <collision>


### PR DESCRIPTION
	modified:   herb_base.urdf.xacro        

- the current implementation just changes the material parameters in the xacro file itself.. 

- I tried to use blender. Blender doesn't have "albedo" parameter explicitly but one could play with diffuse and reflectance parameters to get a material with required light properties.. but somehow when I exported it to collada (which is not the default format of blender), the material properties didn't get exported (even when it was checked) when loaded in rviz..        

- I will keep on exploring this while this PR is a workable solution for now.. better than the pitch black head with no visibility at all..