### PR TITLE
Reorganize URDF

### DIFF
--- a/robots/fixed_transforms.urdf.xacro
+++ b/robots/fixed_transforms.urdf.xacro
@@ -1,6 +1,5 @@
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="fixed_transforms">
     <!-- Fixed Transforms -->
-
     <xacro:macro name="no_inertia">
       <inertial>
         <mass value="0.001"/>
@@ -10,61 +9,31 @@
     
     <xacro:macro name="fixed_transforms">
         
-        <!-- LEFT WAM -->
-        <link name="/left/wam0">
-          <xacro:no_inertia/>
-        </link>
-        <joint
-            name="/left/wam0"
-            type="fixed">
-            <origin
-                xyz="0.22 0.14 .346"
-                rpy="0. 0. 0." />
-            <parent link="/left/wam_base" />
-            <child link="/left/wam0" />
-        </joint>
-        
-        <!-- RIGHT WAM -->
-        <link name="/right/wam0">
-          <xacro:no_inertia/>
-        </link>
-        <joint
-            name="/right/wam0"
-            type="fixed">
-            <origin
-                xyz="0.22 0.14 .346"
-                rpy="0. 0. 0." />
-            <parent link="/right/wam_base" />
-            <child link="/right/wam0" />
-        </joint>
-        
-	<!-- TODO: /head/skel_depth_frame ? -->
-        
-        <link name="stargazer_lens">
-          <xacro:no_inertia/>
-        </link>
-        <joint
-            name="stargazer_lens"
-            type="fixed">
-            <origin
-                xyz="-0.3024 0.2068 1.0258"
-                rpy="0. 0. 0." />
-            <parent link="herb_frame" />
-            <child link="stargazer_lens" />
-        </joint>
-
-        <!-- Dummy link to match ROS conventions. -->
-        <link name="base_link">
-          <xacro:no_inertia/>
-	</link>
-        <joint
-             name="base_link"
-             type="fixed">
-             <origin
-                 xyz="0 0 0"
-                 rpy="0 0 0"/>
-             <parent link="neobotix_base"/> 
-             <child link="base_link"/>
-        </joint>
-    </xacro:macro>
+    <!-- LEFT WAM -->
+    <link name="/left/wam0">
+      <xacro:no_inertia/>
+    </link>
+    <joint
+        name="/left/wam0"
+        type="fixed">
+        <origin
+            xyz="0.22 0.14 .346"
+            rpy="0. 0. 0." />
+        <parent link="/left/wam_base" />
+        <child link="/left/wam0" />
+    </joint>
+    
+    <!-- RIGHT WAM -->
+    <link name="/right/wam0">
+      <xacro:no_inertia/>
+    </link>
+    <joint
+        name="/right/wam0"
+        type="fixed">
+        <origin
+            xyz="0.22 0.14 .346"
+            rpy="0. 0. 0." />
+        <parent link="/right/wam_base" />
+        <child link="/right/wam0" />
+    </joint>
 </robot>

--- a/robots/herb_base.urdf.xacro
+++ b/robots/herb_base.urdf.xacro
@@ -1,9 +1,9 @@
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="herb_base">
   <xacro:macro name="herb_base" params="prefix">
-    <link name="base_footprint">
+    <link name="base_link">
       <inertial>
         <origin
-            xyz="0 0 0"
+            xyz="-0.074086 0 -0.051244"
             rpy="0 0 0" />
         <mass
             value="0.1" />
@@ -16,6 +16,69 @@
             izz="1" />
       </inertial>
     </link>
+    <joint
+        name="root_to_neobotix"
+        type="fixed">
+      <origin
+          xyz="0 0 0"
+          rpy="0 0 1.57075" />
+      <parent
+          link="base_link" />
+      <child
+          link="neobotix_base" />
+    </joint>
+    <link
+        name="neobotix_base">
+      <!--check inertias and mass-->
+      <inertial>
+        <origin
+            xyz="0 0 0"
+            rpy="0 0 0" />
+        <mass
+            value="80" />
+        <inertia
+            ixx="9.25557"
+            ixy="0.00548"
+            ixz="0.00573"
+            iyy="7.60171"
+            iyz="1.02901"
+            izz="9.76036" />
+      </inertial>
+      <visual>
+        <origin
+            xyz="0 0 0"
+            rpy="0 0 0"/>
+        <geometry>
+          <mesh
+              filename="package://herb_description/meshes/base/herb_neobotix_base.STL" />
+        </geometry>
+        <material
+            name="">
+          <color
+              rgba="0.3 0.3 0.3 1" />
+        </material>
+      </visual>
+      <collision>
+        <origin
+            xyz="0 0 0"
+            rpy="1.57075 0 1.57075" />
+        <geometry>
+          <mesh
+              filename="package://herb_description/meshes/base/herb_neobotix_base_collision.STL" />
+        </geometry>
+      </collision>
+    </link>
+    <joint
+        name="neobotix_to_frame"
+        type="fixed">
+      <origin
+          xyz="0 -0.074086 1.101244"
+          rpy="0 0 3.141592" />
+      <parent
+          link="neobotix_base" />
+      <child
+          link="herb_frame" />
+    </joint>
     <link
         name="herb_frame">
       <!--check inertias and mass-->
@@ -57,69 +120,7 @@
         </geometry>
       </collision>
     </link>
-    <joint
-        name="root_to_frame"
-        type="fixed">
-      <origin
-          xyz="0 0 1.05"
-          rpy="0 0 -1.57075" />
-      <parent
-          link="base_footprint" />
-      <child
-          link="herb_frame" />
-    </joint>
-    <link
-        name="neobotix_base">
-      <!--check inertias and mass-->
-      <inertial>
-        <origin
-            xyz="0 -0.074086 -1.101244"
-            rpy="0 0 0" />
-        <mass
-            value="80" />
-        <inertia
-            ixx="9.25557"
-            ixy="0.00548"
-            ixz="0.00573"
-            iyy="7.60171"
-            iyz="1.02901"
-            izz="9.76036" />
-      </inertial>
-      <visual>
-        <origin
-            xyz="0 0 0"
-            rpy="0 0 0"/>
-        <geometry>
-          <mesh
-              filename="package://herb_description/meshes/base/herb_neobotix_base.STL" />
-        </geometry>
-        <material
-            name="">
-          <color
-              rgba="0.3 0.3 0.3 1" />
-        </material>
-      </visual>
-      <collision>
-        <origin
-            xyz="0 0 0"
-            rpy="1.57075 0 1.57075" />
-        <geometry>
-          <mesh
-              filename="package://herb_description/meshes/base/herb_neobotix_base_collision.STL" />
-        </geometry>
-      </collision>
-    </link>
-    <joint
-        name="frame_to_base"
-        type="fixed">
-      <origin
-          xyz="0 -0.074086 -1.101244"
-          rpy="0 0 3.141592" />
-      <parent
-          link="herb_frame" />
-      <child
-          link="neobotix_base" />
-    </joint>
+
     <link
         name="neck_pan">
       <!--check inertias and mass-->

--- a/robots/herb_base.urdf.xacro
+++ b/robots/herb_base.urdf.xacro
@@ -27,6 +27,7 @@
       <child
           link="neobotix_base" />
     </joint>
+    <!--TODO: Confirm the inertial values when deemed important/necessary-->
     <link
         name="neobotix_base">
       <!--check inertias and mass-->


### PR DESCRIPTION
**Issues with the tree**:
Previously we had the following tree that described the base:
base_footprint (5cm above the ground, 7cm in +x direction from base geometric center) --> herb_frame (right below the neck) --> neobotix_base (level with the ground, at the center of the base) --> base_link

1a. base_footprint is unnecessary for wheeled robot.
2a. the tree although correct is extremely convoluted.

**Additional issues:**
1b. The inertia origin for the neobotix frame is defined weirdly, it seems to be 1 meter below the ground. 
2b. Stargazer static tf is being published which is completely unnecessary.

**Issues solved by this PR**
The new tree in this PR solves 1a and 2a:
base_link (level with the ground, at the center) --> neobotix_base (same location, with a change in oritentation to match previous definition) --> herb_frame 

1b is solved by moving the origin for the inertial frame to be the center of the neobotix frame (level with the ground). This might not be correct, I did not find the neobotix documentation to be detailed enough to compute the inertial frame of reference. We do not perform dynamics computation with the base, so this should be fine.

2b. removed static transform from URDF.